### PR TITLE
아키텍처 계층 위반 코드 리팩토링

### DIFF
--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/presentation/AuthController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/presentation/AuthController.java
@@ -1,4 +1,4 @@
-package com.pyeondongbu.editorrecruitment.domain.auth.api;
+package com.pyeondongbu.editorrecruitment.domain.auth.presentation;
 
 import com.pyeondongbu.editorrecruitment.domain.auth.infra.provider.GoogleOauthProvider;
 import jakarta.servlet.http.HttpServletResponse;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/presentation/LoginController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/presentation/LoginController.java
@@ -1,4 +1,4 @@
-package com.pyeondongbu.editorrecruitment.domain.auth.api;
+package com.pyeondongbu.editorrecruitment.domain.auth.presentation;
 
 import com.pyeondongbu.editorrecruitment.domain.auth.annotation.Auth;
 import com.pyeondongbu.editorrecruitment.domain.auth.annotation.MemberOnly;
@@ -70,7 +70,8 @@ public class LoginController {
 
     @DeleteMapping("/account")
     @MemberOnly
-    public ResponseEntity<ApiResponse<Void>> deleteAccount(@Auth final Accessor accessor) {
+    public ResponseEntity<ApiResponse<Void>> deleteAccount(
+            @Auth final Accessor accessor) {
         loginService.deleteAccount(accessor.getMemberId());
         return ResponseEntity.status(204).body(
                 ApiResponse.success(null, 204)

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/image/presentation/ImageController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/image/presentation/ImageController.java
@@ -1,4 +1,4 @@
-package com.pyeondongbu.editorrecruitment.domain.image.api;
+package com.pyeondongbu.editorrecruitment.domain.image.presentation;
 
 import com.pyeondongbu.editorrecruitment.domain.image.dto.response.ImageRes;
 import com.pyeondongbu.editorrecruitment.domain.image.service.ImageService;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/presentation/MemberController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/presentation/MemberController.java
@@ -1,4 +1,4 @@
-package com.pyeondongbu.editorrecruitment.domain.member.api;
+package com.pyeondongbu.editorrecruitment.domain.member.presentation;
 
 import com.pyeondongbu.editorrecruitment.domain.auth.annotation.Auth;
 import com.pyeondongbu.editorrecruitment.domain.auth.annotation.MemberOnly;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/presentation/MemberSearchController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/presentation/MemberSearchController.java
@@ -1,6 +1,5 @@
-package com.pyeondongbu.editorrecruitment.domain.member.api;
+package com.pyeondongbu.editorrecruitment.domain.member.presentation;
 
-import com.pyeondongbu.editorrecruitment.domain.member.dto.response.MemberRes;
 import com.pyeondongbu.editorrecruitment.domain.member.dto.response.MyPageRes;
 import com.pyeondongbu.editorrecruitment.domain.member.service.MemberService;
 import com.pyeondongbu.editorrecruitment.global.dto.ApiResponse;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/ImageUploadController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/ImageUploadController.java
@@ -1,4 +1,4 @@
-package com.pyeondongbu.editorrecruitment.domain.recruitment.api;
+package com.pyeondongbu.editorrecruitment.domain.recruitment.presentation;
 
 import com.pyeondongbu.editorrecruitment.domain.image.domain.ImageFile;
 import com.pyeondongbu.editorrecruitment.domain.image.infra.ImageUploader;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostController.java
@@ -1,4 +1,4 @@
-package com.pyeondongbu.editorrecruitment.domain.recruitment.api;
+package com.pyeondongbu.editorrecruitment.domain.recruitment.presentation;
 
 import com.pyeondongbu.editorrecruitment.domain.auth.annotation.Auth;
 import com.pyeondongbu.editorrecruitment.domain.auth.annotation.MemberOnly;
@@ -38,7 +38,8 @@ public class RecruitmentPostController {
     public ResponseEntity<ApiResponse<RecruitmentPostRes>> getPost(
             @PathVariable("postId") Long postId,
             HttpServletRequest request) {
-        RecruitmentPostRes postResponseDTO = postService.getPost(postId, request);
+        final String remoteAddr = request.getRemoteAddr();
+        RecruitmentPostRes postResponseDTO = postService.getPost(postId, remoteAddr);
         return ResponseEntity.ok(
                 ApiResponse.success(postResponseDTO, 200)
         );

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostSearchController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostSearchController.java
@@ -1,4 +1,4 @@
-package com.pyeondongbu.editorrecruitment.domain.recruitment.api;
+package com.pyeondongbu.editorrecruitment.domain.recruitment.presentation;
 
 import com.pyeondongbu.editorrecruitment.domain.recruitment.dto.response.RecruitmentPostRes;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.service.RecruitmentPostService;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostService.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostService.java
@@ -12,7 +12,7 @@ public interface RecruitmentPostService {
 
     RecruitmentPostRes create(RecruitmentPostReq request, Long memberId);
 
-    RecruitmentPostRes getPost(Long postId, HttpServletRequest request);
+    RecruitmentPostRes getPost(Long postId, String remoteAddr);
 
     List<RecruitmentPostRes> listPosts();
 
@@ -21,6 +21,12 @@ public interface RecruitmentPostService {
     void deletePost(Long postId, Long memberId);
 
 
-    List<RecruitmentPostRes> searchRecruitmentPosts(Integer maxSubs, String title, List<String> skills, List<String> videoTypes, List<String> tagNames);
+    List<RecruitmentPostRes> searchRecruitmentPosts(
+            Integer maxSubs
+            , String title,
+            List<String> skills,
+            List<String> videoTypes,
+            List<String> tagNames
+    );
 
 }

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostServiceImpl.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostServiceImpl.java
@@ -54,11 +54,11 @@ public class RecruitmentPostServiceImpl implements RecruitmentPostService {
     }
 
     @Override
-    public RecruitmentPostRes getPost(Long postId, HttpServletRequest request) {
+    public RecruitmentPostRes getPost(Long postId, String remoteAddr) {
         final RecruitmentPost post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(NOT_FOUND_POST_NAME));
 
-        validationUtils.validatePostView(postId, request);
+        validationUtils.validatePostView(postId, remoteAddr);
 
         post.incrementViewCount();
         postRepository.save(post);

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/tag/presentation/TagController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/tag/presentation/TagController.java
@@ -1,4 +1,4 @@
-package com.pyeondongbu.editorrecruitment.domain.tag.api;
+package com.pyeondongbu.editorrecruitment.domain.tag.presentation;
 
 import com.pyeondongbu.editorrecruitment.domain.tag.dto.TagResDTO;
 import com.pyeondongbu.editorrecruitment.domain.tag.service.TagService;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/validation/PostValidationUtils.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/validation/PostValidationUtils.java
@@ -34,14 +34,14 @@ public class PostValidationUtils {
     private final Validator validator;
 
     @Transactional
-    public void validatePostView(Long postId, HttpServletRequest request) {
-        isValidIp(request.getRemoteAddr());
+    public void validatePostView(Long postId, String remoteAddr) {
+        isValidIp(remoteAddr);
 
-        String postViewId = postId + ":" + request.getRemoteAddr();
+        String postViewId = postId + ":" + remoteAddr;
         boolean isFirstView = !postViewRepository.existsById(postViewId);
 
         if (isFirstView) {
-            postViewRepository.save(new PostView(postViewId, postId, request.getRemoteAddr()));
+            postViewRepository.save(new PostView(postViewId, postId, remoteAddr));
         }
     }
 

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/matching/presentation/MatchingController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/matching/presentation/MatchingController.java
@@ -1,4 +1,4 @@
-package com.pyeondongbu.editorrecruitment.matching.api;
+package com.pyeondongbu.editorrecruitment.matching.presentation;
 
 import com.pyeondongbu.editorrecruitment.domain.auth.annotation.Auth;
 import com.pyeondongbu.editorrecruitment.domain.auth.annotation.MemberOnly;

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/auth/presentation/LoginControllerTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/auth/presentation/LoginControllerTest.java
@@ -1,4 +1,4 @@
-package com.pyeondongbu.editorrecruitment.domain.auth.api;
+package com.pyeondongbu.editorrecruitment.domain.auth.presentation;
 
 
 import static com.pyeondongbu.editorrecruitment.domain.global.restdocs.RestDocsConfiguration.field;;

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/member/api/MemberControllerBadTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/member/api/MemberControllerBadTest.java
@@ -1,4 +1,0 @@
-package com.pyeondongbu.editorrecruitment.domain.member.api;
-
-public class MemberControllerBadTest {
-}

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/member/presentation/MemberControllerBadTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/member/presentation/MemberControllerBadTest.java
@@ -1,0 +1,4 @@
+package com.pyeondongbu.editorrecruitment.domain.member.presentation;
+
+public class MemberControllerBadTest {
+}

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/member/presentation/MemberControllerTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/member/presentation/MemberControllerTest.java
@@ -1,8 +1,7 @@
-package com.pyeondongbu.editorrecruitment.domain.member.api;
+package com.pyeondongbu.editorrecruitment.domain.member.presentation;
 
 import static com.pyeondongbu.editorrecruitment.domain.global.restdocs.RestDocsConfiguration.field;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -13,7 +12,6 @@ import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWit
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -24,16 +22,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.pyeondongbu.editorrecruitment.domain.auth.api.LoginController;
 import com.pyeondongbu.editorrecruitment.domain.auth.domain.MemberTokens;
-import com.pyeondongbu.editorrecruitment.domain.auth.service.LoginService;
 import com.pyeondongbu.editorrecruitment.domain.global.ControllerTest;
 import com.pyeondongbu.editorrecruitment.domain.member.domain.Member;
 import com.pyeondongbu.editorrecruitment.domain.member.domain.details.MemberDetails;
 import com.pyeondongbu.editorrecruitment.domain.member.domain.role.Role;
-import com.pyeondongbu.editorrecruitment.domain.member.dto.request.MemberDetailsReq;
 import com.pyeondongbu.editorrecruitment.domain.member.dto.request.MyPageReq;
-import com.pyeondongbu.editorrecruitment.domain.member.dto.response.MemberDetailsRes;
 import com.pyeondongbu.editorrecruitment.domain.member.dto.response.MyPageRes;
 import com.pyeondongbu.editorrecruitment.domain.member.service.MemberServiceImpl;
 import com.pyeondongbu.editorrecruitment.global.config.WebConfig;

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostControllerTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostControllerTest.java
@@ -1,4 +1,4 @@
-package com.pyeondongbu.editorrecruitment.domain.recruitment.api;
+package com.pyeondongbu.editorrecruitment.domain.recruitment.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pyeondongbu.editorrecruitment.domain.auth.domain.MemberTokens;

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostSearchControllerTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostSearchControllerTest.java
@@ -1,8 +1,7 @@
-package com.pyeondongbu.editorrecruitment.domain.recruitment.api;
+package com.pyeondongbu.editorrecruitment.domain.recruitment.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pyeondongbu.editorrecruitment.domain.global.ControllerTest;
-import com.pyeondongbu.editorrecruitment.domain.recruitment.domain.type.PaymentType;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.dto.PaymentDTO;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.dto.response.RecruitmentPostRes;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.dto.response.RecruitmentPostDetailsRes;

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentServiceImplBadTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentServiceImplBadTest.java
@@ -93,7 +93,7 @@ class RecruitmentServiceImplBadTest {
                 .build();
 
         given(memberRepository.findById(validMemberId)).willReturn(Optional.of(member));
-        doThrow(new TagException(INVALID_PAYMENT)).when(postValidationUtils).validateTagsName(testPostReqDTO.getTagNames());
+        doThrow(new TagException(INVALID_PAYMENT)).when(postValidationUtils).validateRecruitmentPostReq(testPostReqDTO);
 
         // when & then
         assertThatThrownBy(() -> postService.create(testPostReqDTO, validMemberId))
@@ -119,7 +119,7 @@ class RecruitmentServiceImplBadTest {
                 .build();
 
         given(memberRepository.findById(validMemberId)).willReturn(Optional.of(member));
-        doThrow(new InvalidDomainException(INVALID_PAYMENT)).when(postValidationUtils).validatePayments(testPostReqDTO.getPayments());
+        doThrow(new InvalidDomainException(INVALID_PAYMENT)).when(postValidationUtils).validateRecruitmentPostReq(testPostReqDTO);
 
         // when & then
         assertThatThrownBy(() -> postService.create(testPostReqDTO, validMemberId))
@@ -134,7 +134,7 @@ class RecruitmentServiceImplBadTest {
         given(postRepository.findById(postId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> postService.getPost(postId, new MockHttpServletRequest()))
+        assertThatThrownBy(() -> postService.getPost(postId, new MockHttpServletRequest().getRemoteAddr()))
                 .isInstanceOf(PostException.class);
     }
 
@@ -152,10 +152,10 @@ class RecruitmentServiceImplBadTest {
 
         given(postRepository.findById(postId)).willReturn(Optional.of(post));
         doThrow(new BadRequestException(INVALID_IP_ADDRESS))
-                .when(postValidationUtils).validatePostView(eq(postId), eq(request));
+                .when(postValidationUtils).validatePostView(eq(postId), eq(request.getRemoteAddr()));
 
         // when & then
-        assertThatThrownBy(() -> postService.getPost(postId, request))
+        assertThatThrownBy(() -> postService.getPost(postId, request.getRemoteAddr()))
                 .isInstanceOf(BadRequestException.class);
     }
 
@@ -177,7 +177,7 @@ class RecruitmentServiceImplBadTest {
                 .build();
 
         given(postRepository.findByMemberIdAndId(memberId, postId)).willReturn(Optional.of(post));
-        doThrow(new TagException(INVALID_PAYMENT)).when(postValidationUtils).validateTagsName(updateReqDTO.getTagNames());
+        doThrow(new TagException(INVALID_PAYMENT)).when(postValidationUtils).validateRecruitmentPostReq(updateReqDTO);
 
         // when & then
         assertThatThrownBy(() -> postService.update(postId, updateReqDTO, memberId))

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentServiceImplTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentServiceImplTest.java
@@ -126,8 +126,13 @@ class RecruitmentServiceImplTest {
         expectedPost.setDetails(postDetails);
 
         given(memberRepository.findById(any())).willReturn(Optional.of(member));
-        given(postValidationUtils.validateTagsName(any())).willReturn(tags);
-        given(postValidationUtils.validatePayments(any())).willReturn(createPaymentSet());
+        given(postValidationUtils.validateRecruitmentPostReq(testPostReqDTO))
+                .willReturn(
+                        new PostValidationUtils.ValidationResult(
+                                tags,
+                                createPaymentSet()
+                        )
+                );
         given(postRepository.save(any())).willReturn(expectedPost);
 
         // when
@@ -184,10 +189,13 @@ class RecruitmentServiceImplTest {
 
         given(postRepository.findByMemberIdAndId(memberId, postId))
                 .willReturn(Optional.of(post));
-        given(postValidationUtils.validateTagsName(updateReqDTO.getTagNames()))
-                .willReturn(updatedTags);
-        given(postValidationUtils.validatePayments(updateReqDTO.getPayments()))
-                .willReturn(createPaymentSet());
+        given(postValidationUtils.validateRecruitmentPostReq(updateReqDTO))
+                .willReturn(
+                        new PostValidationUtils.ValidationResult(
+                                updatedTags,
+                                createPaymentSet()
+                        )
+                );
 
         // when
         RecruitmentPostRes actualPostResDTO = postService.update(postId, updateReqDTO, memberId);

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/tag/presentation/TagControllerTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/tag/presentation/TagControllerTest.java
@@ -1,11 +1,10 @@
-package com.pyeondongbu.editorrecruitment.domain.tag.api;
+package com.pyeondongbu.editorrecruitment.domain.tag.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pyeondongbu.editorrecruitment.domain.global.ControllerTest;
 import com.pyeondongbu.editorrecruitment.domain.tag.dto.TagResDTO;
 import com.pyeondongbu.editorrecruitment.domain.tag.service.TagService;
 import com.pyeondongbu.editorrecruitment.global.config.WebConfig;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +21,6 @@ import java.util.Arrays;
 
 import static com.pyeondongbu.editorrecruitment.domain.global.restdocs.RestDocsConfiguration.field;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;


### PR DESCRIPTION
# 조회수쪽에 HttpServeltRequest 서비스 레이어에서 처리하는 거 수정
- 해당 문제는 웹 어플리케이션(프레젠테이션), 서비스, DAO 3계층으로 나뉘어진 아키텍처 구조를 망치는 문제였음
- 왜냐면 HttpServeltRequest는 프레젠테이션 영역의 오브젝트인데 이게 Service 로직에서 처리 되도록 내가 로직을 작성함..
- 참고로 Service는 Presentation, DAO, Domain 같은 다른 영역이 바뀌어도 불변한 느낌으로 수정이 되어선 안됨