### PR TITLE
매칭 시스템 구인글 위주 검색

### DIFF
--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/domain/Member.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/domain/Member.java
@@ -1,9 +1,7 @@
 package com.pyeondongbu.editorrecruitment.domain.member.domain;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.pyeondongbu.editorrecruitment.domain.member.domain.details.MemberDetails;
 import com.pyeondongbu.editorrecruitment.domain.member.domain.role.Role;
-import com.pyeondongbu.editorrecruitment.global.exception.MemberException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,7 +14,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 import static com.pyeondongbu.editorrecruitment.domain.member.domain.MemberState.ACTIVE;
-import static com.pyeondongbu.editorrecruitment.global.exception.ErrorCode.*;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.IDENTITY;
 

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/domain/RecruitmentPost.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/domain/RecruitmentPost.java
@@ -77,12 +77,14 @@ public class RecruitmentPost {
 
     @Builder
     public RecruitmentPost(
+            final Long id,
             final String title,
             final String content,
             final Member member,
             final Set<Tag> tags,
             final Set<Payment> payments
     ) {
+        this.id = id;
         this.title = title;
         this.content = content;
         this.member = member;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dto/response/RecruitmentPostRes.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dto/response/RecruitmentPostRes.java
@@ -1,5 +1,7 @@
 package com.pyeondongbu.editorrecruitment.domain.recruitment.dto.response;
 
+import com.pyeondongbu.editorrecruitment.domain.member.domain.Member;
+import com.pyeondongbu.editorrecruitment.domain.recruitment.domain.Payment;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.domain.RecruitmentPost;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.domain.PostImage;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.dto.PaymentDTO;
@@ -8,6 +10,7 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Getter
@@ -43,6 +46,21 @@ public class RecruitmentPostRes {
                 getPaymentsList(post),
                 RecruitmentPostDetailsRes.from(post.getDetails())
         );
+    }
+
+    public RecruitmentPost toEntity(Member member) {
+        return RecruitmentPost.builder()
+                .id(this.id)
+                .title(this.title)
+                .content(this.content)
+                .member(member)
+                .tags(this.tagNames.stream()
+                        .map(tagName -> new Tag(tagName))
+                        .collect(Collectors.toSet()))
+                .payments(this.payments.stream()
+                        .map(paymentDTO -> new Payment(paymentDTO.getType(), paymentDTO.getAmount()))
+                        .collect(Collectors.toSet()))
+                .build();
     }
 
     private static List<String> getImagesUrlList(RecruitmentPost post) {

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostService.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostService.java
@@ -29,4 +29,8 @@ public interface RecruitmentPostService {
             List<String> tagNames
     );
 
+    List<RecruitmentPostRes> searchRecruitmentPostsByTags(
+            List<String> tagNames
+    );
+
 }

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostServiceImpl.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostServiceImpl.java
@@ -101,6 +101,20 @@ public class RecruitmentPostServiceImpl implements RecruitmentPostService {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public List<RecruitmentPostRes> searchRecruitmentPostsByTags(
+            List<String> tagNames
+    ) {
+        Specification<RecruitmentPost> spec = RecruitmentPostSpecification.withTags(
+                tagNames
+        );
+
+        return postRepository.findAll(spec).stream()
+                .map(RecruitmentPostRes::from)
+                .collect(Collectors.toList());
+    }
+
     private RecruitmentPostRes createOrUpdatePost(
             RecruitmentPost post,
             RecruitmentPostReq req,

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/config/WebConfig.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/config/WebConfig.java
@@ -15,7 +15,6 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.util.Arrays;
 import java.util.List;
 
 @Configuration

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/matching/service/MatchingServiceImpl.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/matching/service/MatchingServiceImpl.java
@@ -2,13 +2,14 @@ package com.pyeondongbu.editorrecruitment.matching.service;
 
 import com.pyeondongbu.editorrecruitment.domain.member.dao.MemberRepository;
 import com.pyeondongbu.editorrecruitment.domain.member.domain.Member;
-import com.pyeondongbu.editorrecruitment.domain.recruitment.dao.RecruitmentPostRepository;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.domain.RecruitmentPost;
+import com.pyeondongbu.editorrecruitment.domain.recruitment.dto.response.RecruitmentPostRes;
+import com.pyeondongbu.editorrecruitment.domain.recruitment.service.RecruitmentPostService;
 import com.pyeondongbu.editorrecruitment.global.exception.MemberException;
 import com.pyeondongbu.editorrecruitment.matching.domain.Matcher;
 import com.pyeondongbu.editorrecruitment.matching.domain.MatchingResult;
-import com.pyeondongbu.editorrecruitment.matching.domain.Vectorizer;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,14 +23,21 @@ public class MatchingServiceImpl implements MatchingService {
 
 
     private final MemberRepository memberRepository;
-    private final RecruitmentPostRepository recruitmentPostRepository;
+    private final RecruitmentPostService recruitmentPostService;
     private final Matcher matcher;
+
+    @Value("${recruitment.tag.default}")
+    private String defaultTag;
 
     public List<MatchingResult> findMatchingPosts(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ID));
 
-        List<RecruitmentPost> posts = recruitmentPostRepository.findAll();
+        List<RecruitmentPostRes> postResList = recruitmentPostService.searchRecruitmentPostsByTags(List.of(defaultTag));
+        List<RecruitmentPost> posts = postResList.stream()
+                .map(postRes -> postRes.toEntity(member))
+                .collect(Collectors.toList());
+
         return matcher.match(member, posts);
     }
 


### PR DESCRIPTION
# 매칭 시스템 구인글 위주 검색  #6
- 구인글과 구직글 두개다 매칭되도록 해버림..
- 그래서 태그를 이용해서 구인글과 구직글을 나눌 수 있도록 해줌
- 이 때 태그를 사용한 이유는 나중에 구인, 구직 이외에 여러 태그를 활용할 수 있도록 확장성, 유연성 열어두고 설계