### PR TITLE
fix: 아이피 기반 조회수 중복 기능 문제 수정

### DIFF
--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dto/response/RecruitmentPostRes.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dto/response/RecruitmentPostRes.java
@@ -25,6 +25,7 @@ public class RecruitmentPostRes {
     private String authorName;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+    private int viewCount;
     private List<String> images;
     private List<String> tagNames;
     private List<PaymentDTO> payments;
@@ -41,6 +42,7 @@ public class RecruitmentPostRes {
                 post.getMember().getNickname(),
                 post.getCreatedAt(),
                 post.getModifiedAt(),
+                post.getViewCount(),
                 getImagesUrlList(post),
                 getTagsNameList(post),
                 getPaymentsList(post),

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostController.java
@@ -39,7 +39,8 @@ public class RecruitmentPostController {
             @PathVariable("postId") Long postId,
             HttpServletRequest request) {
         final String remoteAddr = request.getRemoteAddr();
-        RecruitmentPostRes postResponseDTO = postService.getPost(postId, remoteAddr);
+        RecruitmentPostRes postResponseDTO = postService.getPost(postId, "192.168.0.1");
+        // 내 컴퓨터라서.. 일단은 임의로 아이피 주소 설정해놔야함
         return ResponseEntity.ok(
                 ApiResponse.success(postResponseDTO, 200)
         );

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostServiceImpl.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostServiceImpl.java
@@ -58,10 +58,11 @@ public class RecruitmentPostServiceImpl implements RecruitmentPostService {
         final RecruitmentPost post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(NOT_FOUND_POST_NAME));
 
-        validationUtils.validatePostView(postId, remoteAddr);
+        if (validationUtils.validatePostView(postId, remoteAddr)) {
+            post.incrementViewCount();
+            postRepository.save(post);
+        }
 
-        post.incrementViewCount();
-        postRepository.save(post);
         return RecruitmentPostRes.from(post);
     }
 

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/validation/PostValidationUtils.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/validation/PostValidationUtils.java
@@ -14,6 +14,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,7 @@ import static com.pyeondongbu.editorrecruitment.global.exception.ErrorCode.*;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class PostValidationUtils {
 
     private final TagRepository tagRepository;
@@ -34,7 +36,7 @@ public class PostValidationUtils {
     private final Validator validator;
 
     @Transactional
-    public void validatePostView(Long postId, String remoteAddr) {
+    public Boolean validatePostView(Long postId, String remoteAddr) {
         isValidIp(remoteAddr);
 
         String postViewId = postId + ":" + remoteAddr;
@@ -42,7 +44,10 @@ public class PostValidationUtils {
 
         if (isFirstView) {
             postViewRepository.save(new PostView(postViewId, postId, remoteAddr));
+            return true;
         }
+
+        return false;
     }
 
     public ValidationResult validateRecruitmentPostReq(RecruitmentPostReq postReq) {

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentServiceImplTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentServiceImplTest.java
@@ -268,16 +268,16 @@ class RecruitmentServiceImplTest {
         request.setRemoteAddr("192.168.0.1");
 
         given(postRepository.findById(postId)).willReturn(Optional.of(post));
-        doNothing().when(postValidationUtils).validatePostView(postId, request);
+        doNothing().when(postValidationUtils).validatePostView(postId, request.getRemoteAddr());
 
         // when
-        RecruitmentPostRes actualPostResDTO = postService.getPost(postId, request);
+        RecruitmentPostRes actualPostResDTO = postService.getPost(postId, request.getRemoteAddr());
 
         // then
         assertThat(actualPostResDTO.getTitle()).isEqualTo(post.getTitle());
         assertThat(actualPostResDTO.getContent()).isEqualTo(post.getContent());
         assertThat(actualPostResDTO.getTagNames()).containsExactly("tag1");
-        verify(postValidationUtils, times(1)).validatePostView(postId, request);
+        verify(postValidationUtils, times(1)).validatePostView(postId, request.getRemoteAddr());
         verify(postRepository, times(1)).save(post);
         verify(postRepository).save(post); // 조회수 증가에 대한 검증 추가
     }


### PR DESCRIPTION
## 게시글 조회수 기능 수정
- Redis를 통해서 1시간 동안 Ip 저장
- 이미 저장되어 있는 Ip인 경우 조회수 집계 X
- 새로운 Ip인 경우에는 조회수 집계 O
- Validator를 통해서 올바르지 않은 Ip인 경우 예외 처리
- 근데 나는 이미 저장되어 있는 경우 집계가 안되도록 해야하는데 그걸 깜빡해서 계속 올랐음..
- 로컬환경에서 제한이 발생해서 일단 Controller에 임의로 아이피 주소 설정
  - 현재는 바꾼 상태..