### PR TITLE
멤버 세부 정보 강제 기입 및 리팩토링 (#14)

### DIFF
--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/dto/ResponseMessage.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/dto/ResponseMessage.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ResponseMessage {
 
-    FIRST_LOGIN_CHECK(1001, "최초 로그인 요청입니다."),
+    FIRST_LOGIN_OR_ENTER_DETAILS_CHECK(1001, "최초 로그인 또는 세부정보가 없습니다."),
     EXIST_LOGIN_CHECK(1002, "기존 회원의 로그인 요청입니다.");
 
     private final int status;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/validation/MemberValidationUtils.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/validation/MemberValidationUtils.java
@@ -3,10 +3,12 @@ package com.pyeondongbu.editorrecruitment.global.validation;
 import com.pyeondongbu.editorrecruitment.domain.common.dto.request.DetailsReq;
 import com.pyeondongbu.editorrecruitment.domain.member.dao.MemberRepository;
 import com.pyeondongbu.editorrecruitment.domain.member.domain.Member;
+import com.pyeondongbu.editorrecruitment.domain.member.domain.details.MemberDetails;
 import com.pyeondongbu.editorrecruitment.domain.member.domain.role.Role;
 import com.pyeondongbu.editorrecruitment.domain.member.dto.request.MemberDetailsReq;
 import com.pyeondongbu.editorrecruitment.domain.member.dto.request.MyPageReq;
 import com.pyeondongbu.editorrecruitment.global.exception.BadRequestException;
+import com.pyeondongbu.editorrecruitment.global.exception.MemberException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
@@ -61,7 +63,18 @@ public class MemberValidationUtils {
         if (!violations.isEmpty()) {
             throw new BadRequestException(INVALID_MEMBER_DETAILS);
         }
+    }
 
+    public boolean validateMemberDetails(MemberDetails memberDetails) {
+        if (memberDetails == null) {
+            return false;
+        }
 
+        Set<ConstraintViolation<MemberDetails>> violations = validator.validate(memberDetails);
+        if (!violations.isEmpty()) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/domain/RecruitmentPostTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/recruitment/domain/RecruitmentPostTest.java
@@ -2,11 +2,13 @@ package com.pyeondongbu.editorrecruitment.domain.recruitment.domain;
 
 
 import com.pyeondongbu.editorrecruitment.domain.member.domain.Member;
+import com.pyeondongbu.editorrecruitment.domain.recruitment.dto.request.RecruitmentPostReq;
 import com.pyeondongbu.editorrecruitment.domain.tag.domain.Tag;
 import com.pyeondongbu.editorrecruitment.global.exception.InvalidDomainException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -114,13 +116,18 @@ class RecruitmentPostTest {
 
         final String expectedTitle = "UpdatedTitle";
         final String expectedContent = "UpdatedContent";
-        final Set<Tag> expectedTags = new HashSet<>();
+        final List<String> expectedTags = new ArrayList<>();
+        // 테스트 코드 짜기 편하게 일단 Req에 맞춰서 선언
+
+       final RecruitmentPostReq req = RecruitmentPostReq.builder()
+                .title(expectedTitle)
+                .content(expectedContent)
+                .tagNames(expectedTags)
+                .build();
 
         // when
         post.update(
-                expectedTitle,
-                expectedContent,
-                expectedTags,
+                req,
                 null
         );
 


### PR DESCRIPTION
## 멤버 세부 정보 강제 기입 및 리팩토링
- 로그인 시 세부 정보 입력을 프론트에 알릴 수 있도록 코드 수정
- ApiResponse의 Message를 활용
- ResponseMessage도 이에 맞춰서 수정
- 매칭 시스템 및 구인 작성 시 ApiResponse로 메시지 보낼 수 있도록 수정해야함