### PR TITLE
구인 기능 N + 1 문제 확인 및 해결, Fetch Join과 서브 쿼리 활용 (#18)

### DIFF
--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/service/LoginServiceImpl.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/service/LoginServiceImpl.java
@@ -90,15 +90,17 @@ public class LoginServiceImpl implements LoginService {
 
     @Override
     public Boolean checkMember(final String socialLoginId) {
-        final Member member = memberRepository.findBySocialLoginId(socialLoginId)
-                .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ID));
-
+        final Optional<Member> optionalMember = memberRepository.findBySocialLoginId(socialLoginId);
+        if (!optionalMember.isPresent()) {
+            return false;
+        }
+        final Member member = optionalMember.get();
         if (memberValidationUtils.validateMemberDetails(member)) {
             return false;
         }
-
-        return memberRepository.findBySocialLoginId(socialLoginId).isPresent();
+        return true;
     }
+
 
     @Override
     @Transactional

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/common/domain/Details.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/common/domain/Details.java
@@ -11,7 +11,9 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @MappedSuperclass
 @Getter
@@ -29,17 +31,17 @@ public abstract class Details {
 
     @ElementCollection
     @Column(name = "skill")
-    protected List<String> skills;
+    protected Set<String> skills = new HashSet<>();
 
     @ElementCollection
     @Column(name = "video_type")
-    protected List<String> videoTypes;
+    protected Set<String> videoTypes = new HashSet<>();
 
     public Details(
             int maxSubs,
             String remarks,
-            List<String> skills,
-            List<String> videoTypes
+            Set<String> skills,
+            Set<String> videoTypes
     ) {
         this.maxSubs = maxSubs;
         this.remarks = remarks;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/common/dto/request/DetailsReq.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/common/dto/request/DetailsReq.java
@@ -8,6 +8,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,11 +19,11 @@ public abstract class DetailsReq {
     private int maxSubs;
 
     @NotNull(message = "장르는 공백이 될 수 없습니다.")
-    private List<String> videoTypes;
+    private Set<String> videoTypes;
 
     @NotNull(message = "스킬 리스트는 필수입니다.")
     @Size(min = 1, message = "최소한 하나 이상의 스킬이 필요합니다.")
-    private List<String> skills;
+    private Set<String> skills;
 
     @Size(max = 1000, message = "비고란은 1000자를 초과할 수 없습니다.")
     private String remarks;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/domain/details/MemberDetails.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/domain/details/MemberDetails.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @DiscriminatorValue("MEMBER")
@@ -36,8 +37,8 @@ public class MemberDetails extends Details {
     public MemberDetails(
             int maxSubs,
             String remarks,
-            List<String> skills,
-            List<String> videoTypes,
+            Set<String> skills,
+            Set<String> videoTypes,
             List<String> editedChannels,
             List<String> currentChannels,
             String portfolio,

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/dto/request/MemberDetailsReq.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/dto/request/MemberDetailsReq.java
@@ -7,6 +7,7 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,8 +24,8 @@ public class MemberDetailsReq extends DetailsReq {
     @Builder
     public MemberDetailsReq(
             final int maxSubs,
-            final List<String> videoTypes,
-            final List<String> skills,
+            final Set<String> videoTypes,
+            final Set<String> skills,
             final String remarks,
             final List<String> editedChannels,
             final List<String> currentChannels,

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/dto/response/MemberDetailsRes.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/dto/response/MemberDetailsRes.java
@@ -4,6 +4,7 @@ import com.pyeondongbu.editorrecruitment.domain.member.domain.details.MemberDeta
 import lombok.*;
 
 import java.util.List;
+import java.util.Set;
 
 @Getter // 어노테이션 선택 정리
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -11,11 +12,11 @@ import java.util.List;
 public class MemberDetailsRes {
 
     private int maxSubs;
-    private List<String> videoTypes;
+    private Set<String> videoTypes;
     private List<String> editedChannels;
     private List<String> currentChannels;
     private String portfolio;
-    private List<String> skills;
+    private Set<String> skills;
     private String remarks;
 
     public static MemberDetailsRes from(MemberDetails memberDetails) {

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dao/RecruitmentPostRepository.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dao/RecruitmentPostRepository.java
@@ -24,4 +24,25 @@ public interface RecruitmentPostRepository extends JpaRepository<RecruitmentPost
     @Modifying
     @Query("DELETE FROM RecruitmentPost p WHERE p.id IN :postIds")
     void deleteByPostIds(@Param("postIds") final List<Long> postIds);
+
+    @Query("SELECT rp FROM RecruitmentPost rp " +
+            "LEFT JOIN FETCH rp.details d " +
+            "LEFT JOIN FETCH rp.tags t " +
+            "LEFT JOIN FETCH rp.payments p " +
+            "LEFT JOIN FETCH rp.images i " +
+            "LEFT JOIN FETCH d.skills s " +
+            "LEFT JOIN FETCH d.videoTypes v " +
+            "WHERE rp.id = :id")
+    RecruitmentPost findByIdWithDetails(@Param("id") Long id);
+
+    @Query("SELECT rp FROM RecruitmentPost rp " +
+            "LEFT JOIN FETCH rp.details d " +
+            "LEFT JOIN FETCH rp.tags t " +
+            "LEFT JOIN FETCH rp.images i " +
+            "LEFT JOIN FETCH d.skills s " +
+            "LEFT JOIN FETCH d.videoTypes v " +
+            "WHERE rp.id IN (SELECT DISTINCT rp.id FROM RecruitmentPost rp " +
+            "LEFT JOIN rp.payments p)")
+    List<RecruitmentPost> findAllWithDetails();
+
 }

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/domain/details/RecruitmentPostDetails.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/domain/details/RecruitmentPostDetails.java
@@ -11,6 +11,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @DiscriminatorValue("RECRUITMENT_POST")
@@ -29,8 +30,8 @@ public class RecruitmentPostDetails extends Details {
     public RecruitmentPostDetails(
             int maxSubs,
             String remarks,
-            List<String> skills,
-            List<String> videoTypes,
+            Set<String> skills,
+            Set<String> videoTypes,
             RecruitmentPost recruitmentPost
     ) {
         super(maxSubs, remarks, skills, videoTypes);

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dto/request/RecruitmentPostDetailsReq.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dto/request/RecruitmentPostDetailsReq.java
@@ -5,6 +5,7 @@ import com.pyeondongbu.editorrecruitment.domain.recruitment.domain.details.Recru
 import lombok.*;
 
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -13,8 +14,8 @@ public class RecruitmentPostDetailsReq extends DetailsReq {
     @Builder
     public RecruitmentPostDetailsReq(
             final int maxSubs,
-            final List<String> videoTypes,
-            final List<String> skills,
+            final Set<String> videoTypes,
+            final Set<String> skills,
             final String remarks
     ) {
         super(maxSubs, videoTypes, skills, remarks);

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dto/response/RecruitmentPostDetailsRes.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dto/response/RecruitmentPostDetailsRes.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -17,8 +18,8 @@ import java.util.List;
 public class RecruitmentPostDetailsRes {
 
     private int maxSubs;
-    private List<String> videoTypes;
-    private List<String> skills;
+    private Set<String> videoTypes;
+    private Set<String> skills;
     private String remarks;
 
     public static RecruitmentPostDetailsRes from(

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/presentation/RecruitmentPostController.java
@@ -42,7 +42,7 @@ public class RecruitmentPostController {
         String remoteAddr = request.getRemoteAddr();
         if (forwardedFor != null && !forwardedFor.isEmpty()) {
             remoteAddr = forwardedFor.split(",")[0].trim();
-        } // Ip 주소 받아오기,
+        }
 
         RecruitmentPostRes postResponseDTO = postService.getPost(postId, remoteAddr);
         return ResponseEntity.ok(ApiResponse.success(postResponseDTO, 200));

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostServiceImpl.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostServiceImpl.java
@@ -75,7 +75,8 @@ public class RecruitmentPostServiceImpl implements RecruitmentPostService {
 
     @Override
     public List<RecruitmentPostRes> listPosts() {
-        return postRepository.findAll().stream()
+        final List<RecruitmentPost> posts = postRepository.findAllWithDetails();
+        return posts.stream()
                 .map(RecruitmentPostRes::from)
                 .collect(Collectors.toList());
     }

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/matching/presentation/MatchingController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/matching/presentation/MatchingController.java
@@ -23,7 +23,7 @@ public class MatchingController {
     @GetMapping
     @MemberOnly
     public ResponseEntity<ApiResponse<MatchingRes>> getMatchingPosts(
-            @Auth final Accessor accessor
+             @Auth final Accessor accessor
     ) {
         MatchingRes matchingRes = matchingService.findMatchingPosts(accessor.getMemberId());
         return ResponseEntity.ok(


### PR DESCRIPTION
## 구인 기능 N + 1 문제 확인 및 해결

- N + 1 문제 전체 점검
  - 모든 엔티티와 그 연관 관계를 점검하여 n + 1 문제 발생 가능성을 확인
  - 해결해야 할 부분들 목록 작성 및 우선순위 설정
- N + 1 문제 해결 방법 선택
  - Join Fetch와 서브 쿼리 활용
  : 여러 연관된 엔티티를 한 번의 쿼리로 가져오도록 최적화
  - Set을 활용한 방법
  : Java 코드에서 중복된 데이터를 제거하여 성능 최적화
- 구인글 전체 조회 N + 1 문제 확인
  - 문제 발생
  : 8번의 쿼리가 실행되어 성능 저하 문제 발생
  - 쿼리 최적화
  : 3번의 쿼리(서브 쿼리 2회)로 쿼리를 최적화하여 성능 향상
