### PR TITLE
멤버 Details 강제 추가 구현 & 예외 핸들러 추가 (#22)

### DIFF
--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/dto/LoginRes.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/dto/LoginRes.java
@@ -1,5 +1,6 @@
 package com.pyeondongbu.editorrecruitment.domain.auth.dto;
 
+import com.pyeondongbu.editorrecruitment.domain.member.domain.Member;
 import lombok.*;
 
 @Getter
@@ -8,20 +9,17 @@ public class LoginRes {
 
     private final String accessToken;
     private final String refreshToken;
-    private final Integer code;
-    private final String message;
+    private final Member member;
 
     public static LoginRes from(
             final String accessToken,
             final String refreshToken,
-            final Integer code,
-            final String message
+            final Member member
     ) {
         return new LoginRes(
                 accessToken,
                 refreshToken,
-                code,
-                message
+                member
         );
     }
 

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/presentation/LoginController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/presentation/LoginController.java
@@ -28,7 +28,7 @@ public class LoginController {
     private final LoginService loginService;
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<AccessTokenRes>> login(
+    public ResponseEntity<ApiResponse<LoginRes>> login(
             @RequestBody final LoginReq loginReq,
             final HttpServletResponse response
     ) {
@@ -42,7 +42,7 @@ public class LoginController {
         response.addHeader(SET_COOKIE, cookie.toString());
 
         return ResponseEntity.ok(
-                ApiResponse.success(new AccessTokenRes(res.getAccessToken()), res.getCode(), res.getMessage())
+                ApiResponse.success(res, 201)
         );
     }
 

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/service/LoginService.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/auth/service/LoginService.java
@@ -12,8 +12,6 @@ public interface LoginService {
 
     Member createMember(final String socialLoginId, final String nickname, final String imageUrl);
 
-    Boolean checkMember(final String socialLoginId);
-
     String generateRandomFourDigitCode();
 
     String renewalAccessToken(final String refreshTokenRequest, final String authorizationHeader);

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/annotation/CheckDetails.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/annotation/CheckDetails.java
@@ -1,0 +1,11 @@
+package com.pyeondongbu.editorrecruitment.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckDetails {
+}

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/aspect/DistributedLockAspect.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/aspect/DistributedLockAspect.java
@@ -9,12 +9,9 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
-import java.util.concurrent.TimeUnit;
 
 @Aspect
 @Component

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/dto/ApiResponse.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/dto/ApiResponse.java
@@ -22,4 +22,8 @@ public class ApiResponse<T> {
     public static ApiResponse<?> error(ErrorCode e, int status) {
         return new ApiResponse<>(Integer.toString(status), "fail", e);
     }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
 }

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/exception/ExceptionResponse.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/exception/ExceptionResponse.java
@@ -1,0 +1,12 @@
+package com.pyeondongbu.editorrecruitment.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ExceptionResponse {
+
+    private final int code;
+    private final String message;
+}

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/exception/GlobalExceptionHandler.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,80 @@
+package com.pyeondongbu.editorrecruitment.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Objects;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import static com.pyeondongbu.editorrecruitment.global.exception.ErrorCode.*;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            final MethodArgumentNotValidException e,
+            final HttpHeaders headers,
+            final HttpStatusCode status,
+            final WebRequest request
+    ) {
+        log.warn(e.getMessage(), e);
+
+        final String errMessage = Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage();
+        return ResponseEntity.badRequest()
+                .body(new ExceptionResponse(INVALID_REQUEST.getStatus(), errMessage));
+    }
+
+    @ExceptionHandler(SizeLimitExceededException.class)
+    public ResponseEntity<ExceptionResponse> handleSizeLimitExceededException(final SizeLimitExceededException e) {
+        log.warn(e.getMessage(), e);
+
+        final String message = EXCEED_IMAGE_CAPACITY.getMessage()
+                + " 입력된 이미지 용량은 " + e.getActualSize() + " byte 입니다. "
+                + "(제한 용량: " + e.getPermittedSize() + " byte)";
+        return ResponseEntity.badRequest()
+                .body(new ExceptionResponse(EXCEED_IMAGE_CAPACITY.getStatus(), message));
+    }
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ExceptionResponse> handleAuthException(final AuthException e) {
+        log.warn(e.getMessage(), e);
+
+        return ResponseEntity.badRequest()
+                .body(new ExceptionResponse(e.getStatus(), e.getMessage()));
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ExceptionResponse> handleBadRequestException(final BadRequestException e) {
+        log.warn(e.getMessage(), e);
+
+        return ResponseEntity.badRequest()
+                .body(new ExceptionResponse(e.getStatus(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<ExceptionResponse> handleMemberException(final MemberException e) {
+        log.warn(e.getMessage(), e);
+
+        return ResponseEntity.badRequest()
+                .body(new ExceptionResponse(e.getStatus(), e.getMessage()));
+    }
+
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleException(final Exception e) {
+        log.error(e.getMessage(), e);
+
+        return ResponseEntity.internalServerError()
+                .body(new ExceptionResponse(INTERNAL_SEVER_ERROR.getStatus(), INTERNAL_SEVER_ERROR.getMessage()));
+    }
+}
+

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/matching/service/MatchingServiceImpl.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/matching/service/MatchingServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 
 import static com.pyeondongbu.editorrecruitment.global.dto.ResponseMessage.FIRST_LOGIN_OR_ENTER_DETAILS_CHECK;
 import static com.pyeondongbu.editorrecruitment.global.dto.ResponseMessage.SUCCESS_REQUEST;
+import static com.pyeondongbu.editorrecruitment.global.exception.ErrorCode.INVALID_MEMBER_DETAILS;
 import static com.pyeondongbu.editorrecruitment.global.exception.ErrorCode.NOT_FOUND_MEMBER_ID;
 
 @Service
@@ -41,11 +42,8 @@ public class MatchingServiceImpl implements MatchingService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER_ID));
 
-        if(memberValidationUtils.validateMemberDetails(member)){
-            return MatchingRes.from(
-                    matcher.match(member, null),
-                    FIRST_LOGIN_OR_ENTER_DETAILS_CHECK.getMessage()
-            );
+        if (memberValidationUtils.validateMemberDetails(member)) {
+            throw new MemberException(INVALID_MEMBER_DETAILS);
         }
 
         List<RecruitmentPostRes> postResList = recruitmentPostService.searchRecruitmentPostsByTags(List.of(defaultTag));

--- a/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/auth/presentation/LoginControllerTest.java
+++ b/Backend/editor-recruitment/src/test/java/com/pyeondongbu/editorrecruitment/domain/auth/presentation/LoginControllerTest.java
@@ -3,7 +3,6 @@ package com.pyeondongbu.editorrecruitment.domain.auth.presentation;
 
 import static com.pyeondongbu.editorrecruitment.domain.global.restdocs.RestDocsConfiguration.field;;
 import static com.pyeondongbu.editorrecruitment.global.dto.ResponseMessage.EXIST_LOGIN_CHECK;
-import static com.pyeondongbu.editorrecruitment.global.dto.ResponseMessage.FIRST_LOGIN_CHECK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;


### PR DESCRIPTION
## 멤버 Details 강제 추가 구현 & 예외 핸들러 추가 (#22)
- AOP, 이벤트 리스너, 헬퍼 메소드를 사용해서 멤버에 Details가 없을 경우 응답에 예외 메시지를 포함하여 처리하고자 했음
  - 하지만 오히려 코드가 복잡해지고 가독성이 떨어지는 문제가 있는걸로 확인
  - 때문에 간단하고 명료한 방법으로 백엔드 & 프론트에서 Member Details를 확인하는 방향으로 수정
- 로그인 시 응답에 Member를 포함하여 프론트에서 Details를 확인
- 매칭 시스템과 같이 Details가 강제로 필요한 상황인 경우 예외 반환
  - 글로버 예외 핸들러를 추가하여 각기 다른 예외 상황을 적절하게 처리하는 방식