### PR TITLE
Header 퍼블리싱 작업 완료 (#28)

### DIFF
--- a/Frontend/editor-recruitment-front/package-lock.json
+++ b/Frontend/editor-recruitment-front/package-lock.json
@@ -20,6 +20,7 @@
         "quill": "^2.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.3.0",
         "react-query": "^3.39.3",
         "react-quill": "^2.0.0",
         "react-router-dom": "^6.23.1",
@@ -17902,6 +17903,15 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -35882,6 +35892,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/Frontend/editor-recruitment-front/package.json
+++ b/Frontend/editor-recruitment-front/package.json
@@ -15,6 +15,7 @@
     "quill": "^2.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.3.0",
     "react-query": "^3.39.3",
     "react-quill": "^2.0.0",
     "react-router-dom": "^6.23.1",

--- a/Frontend/editor-recruitment-front/src/components/Header.tsx
+++ b/Frontend/editor-recruitment-front/src/components/Header.tsx
@@ -1,15 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/Header.css'; // 스타일 임포트
+import { AiOutlineSearch } from 'react-icons/ai'; // 돋보기 아이콘 임포트
 
 // 로그인 상태를 확인하는 함수 (JWT 토큰 확인)
 const checkLoginStatus = () => {
-    return sessionStorage.getItem('token') !== null; // 토큰 확인
+    return sessionStorage.getItem('access-token') !== null; // 토큰 확인
 };
 
 const Header = () => {
     const [isLoggedIn, setIsLoggedIn] = useState(false);
     const [showDropdown, setShowDropdown] = useState(false); // 드롭다운 상태
+    const [searchQuery, setSearchQuery] = useState(''); // 검색어 상태
     const navigate = useNavigate(); // useNavigate 훅
 
     // 컴포넌트가 마운트되면 로그인 상태 확인
@@ -40,15 +42,47 @@ const Header = () => {
         }
     };
 
+    const handleSearch = () => {
+        if (searchQuery.trim()) {
+            navigate(`/search?query=${searchQuery}`); // 검색 페이지로 이동
+        }
+    };
+
+    const handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter') {
+            handleSearch(); // 엔터 키로 검색 실행
+        }
+    };    
+
     return (
         <header className="header">
-            <h1 className="header-title" onClick={() => navigate('/')}>PDB</h1>
-            <div className="header-actions">
-                <button className="post-button" onClick={handlePostPage}>
-                    구인 | 구직 하러가기
-                </button>
+            <div className="left-section">
+                <img src="https://ifh.cc/g/PDRy1k.png" alt="Logo" className="logo" />
+                <h1 className="header-title" onClick={() => navigate('/')}>PDB</h1>
+                <nav className="nav-menu">
+                    <span onClick={() => navigate('/jobs')}>작업 찾기</span>
+                    <span onClick={() => navigate('/workers')}>작업자 찾기</span>
+                    <span onClick={() => navigate('/community')}>커뮤니티</span>
+                </nav>
+            </div>
+            <div className="right-section">
+                <div className="search-bar">
+                    <AiOutlineSearch className="search-icon" onClick={handleSearch} />
+                    <input
+                        type="text"
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        onKeyPress={handleKeyPress}
+                        placeholder="파트너를 찾아보세요"
+                        className="search-input"
+                    />
+                </div>
                 {isLoggedIn ? (
                     <>
+                        <button className="match-button" onClick={() => navigate('/match')}>파트너 매칭하기</button>
+                        <button className="post-button" onClick={handlePostPage}>
+                            구인 | 구직 하기
+                        </button>
                         <div className="profile-wrap" onClick={toggleDropdown}>
                             <img src="https://ifh.cc/g/q2ZvDd.jpg" alt="Profile" className="profile-image" />
                             {showDropdown && (
@@ -60,7 +94,10 @@ const Header = () => {
                         </div>
                     </>
                 ) : (
-                    <button className="google-login-button" onClick={handleLogin}>Google Login</button>
+                    <button className="google-login-button" onClick={handleLogin}>
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/5/53/Google_%22G%22_Logo.svg" alt="Google Icon" className="google-icon" />
+                        구글 로그인
+                    </button>
                 )}
             </div>
         </header>

--- a/Frontend/editor-recruitment-front/src/index.css
+++ b/Frontend/editor-recruitment-front/src/index.css
@@ -1,0 +1,21 @@
+@font-face {
+    font-family: 'Pretendard-Regular';
+    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
+    font-weight: 400;
+    font-style: normal;
+}
+
+/* 폰트를 모든 텍스트 요소에 적용 */
+html, body {
+    font-family: 'Pretendard-Regular', sans-serif;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+}
+
+#root {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+}

--- a/Frontend/editor-recruitment-front/src/index.tsx
+++ b/Frontend/editor-recruitment-front/src/index.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import { GoogleOAuthProvider } from '@react-oauth/google'; // GoogleOAuthProvider 가져오기
+import 'index.css';
 
 const clientId = process.env.REACT_APP_GOOGLE_CLIENT_ID;
 

--- a/Frontend/editor-recruitment-front/src/styles/Header.css
+++ b/Frontend/editor-recruitment-front/src/styles/Header.css
@@ -1,30 +1,87 @@
-/* Header 스타일 */
 .header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     width: 100vw;
-    background-color: #f8f9fa;
+    height: 6.5vh;
     border-bottom: 1px solid #ddd;
-    padding: 0.5rem 1rem;
+    font-family: 'Pretendard', sans-serif; /* Pretendard 폰트 사용 */
+    box-shadow: 0px 4px 10px 0px rgba(140, 140, 140, 0.25);
 }
 
-.header-title {
-    font-size: 1.5rem;
-    margin: 10px;
-    font-weight: bold;
-    cursor: pointer; /* 제목 클릭 시 커서 변경 */
-}
-
-.header-actions {
+.left-section {
     display: flex;
     align-items: center;
 }
 
-.google-login-button,
-.logout-button {
+.left-section .logo{
+    width: 30px;
+    height: 30px;
+    margin-left: 1rem;
+    cursor: pointer;
+}
+
+.header-title {
+    font-size: 1.25rem;
+    margin-right: 3rem;
+    font-weight: 600;
+    margin-left: 2px;
+    margin-bottom: 8px;
+    cursor: pointer; 
+}
+
+.nav-menu {
+    display: flex;
+    gap: 1.5rem;
+    font-weight: 600;
+}
+
+.nav-menu span {
+    cursor: pointer;
+    font-size: 1rem;
+    color: #333;
+}
+
+.nav-menu span:hover {
+    text-decoration: underline;
+}
+
+.right-section {
+    display: flex;
+    align-items: center;
+}
+
+.right-section .search-bar {
+    display: flex;
+    align-items: center;
+    background-color: #f0f0f0;
+    padding: 0.15rem 0.15rem;
+    border-radius: 20px;
+    margin-right: 1rem;
+}
+
+.right-section .search-icon {
+    color: #767676;
+    cursor: pointer;
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+}
+
+.right-section .search-input {
+    border: none;
+    background: none;
+    outline: none;
+    font-size: 14px;
+    color: #767676;
+    width: 150px;
+    padding: 0.5rem;
+}
+
+.google-login-button {
+    display: flex;
+    align-items: center;
     padding: 10px;
-    margin: 10px;
+    margin-left: 10px;
     background-color: #4285f4;
     color: white;
     border: none;
@@ -32,25 +89,49 @@
     cursor: pointer;
 }
 
-.google-login-button:hover,
-.logout-button:hover {
+.google-icon {
+    width: 18px;
+    height: 18px;
+    margin-right: 8px;
+}
+
+.google-login-button:hover {
     background-color: #357ae8;
+}
+
+.match-button, .post-button {
+    padding: 10px 20px;
+    margin: 0 10px;
+    border: none;
+    border-radius: 20px; /* 둥근 버튼 */
+    font-size: 12px;
+    font-weight: 400;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.post-button {
+    margin-right: 25px;
+}
+
+.match-button:hover, .post-button:hover {
+    background-color: #00CBD6;
+    color: white;
 }
 
 .profile-wrap {
     position: relative;
     display: inline-block;
-    margin-left: 1rem;
     cursor: pointer;
 }
 
 .profile-wrap .profile-image {
-    margin-right: 30px;
-    width: 40px;
-    height: 40px;
+    width: 35px;
+    height: 35px;
     border-radius: 50%;
     object-fit: cover;
     margin-bottom: auto;
+    margin-right: 1rem;
 }
 
 .dropdown-menu {
@@ -64,26 +145,6 @@
     border-radius: 4px;
 }
 
-/* 구인 | 구직 하러가기 버튼 */
-.post-button {
-    padding: 10px 20px;
-    margin: 10px;
-    background-color: #00b894;
-    color: white;
-    border: none;
-    border-radius: 20px; /* 둥근 버튼 */
-    font-size: 12px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
-}
-
-/* 버튼 hover 효과 */
-.post-button:hover {
-    background-color: #019267; /* 호버 시 색상 변경 */
-}
-
-/* 드롭다운 스타일 */
 .dropdown-menu button {
     padding: 0.7rem 0.7rem;
     width: 100%;

--- a/Frontend/editor-recruitment-front/src/styles/MainPage.css
+++ b/Frontend/editor-recruitment-front/src/styles/MainPage.css
@@ -3,7 +3,6 @@
 .main-page {
     display: flex;
     flex-direction: column;
-    min-height: 100vh;
     font-family: 'Arial', sans-serif;
 }
 
@@ -15,11 +14,6 @@
     align-items: center;
 }
 
-.header {
-    width: 100%;
-    background-color: #f5f5f5;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
 
 .footer {
     width: 100%;

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Header 퍼블리싱 작업 완료 (#28)
- UI/UX 디자인에 맞춰서 퍼블리싱 작업 완료
  - 헤더 컴포넌트에 로고 추가 (로고를 타이틀 왼쪽에 배치)
  - 화면 전체 폭이 100%로 채워지지 않던 문제 수정 (Root 요소의 width를 100%로 설정)
  - Pretendard-Regular 폰트를 @font-face 규칙으로 글로벌하게 적용
  - 검색 기능 개선 (검색어 입력 후 Enter 키로 검색 가능하게 수정)
  - 드롭다운 메뉴 스타일 및 프로필 이미지 클릭 시 드롭다운 표시 문제 해결

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/8e26ce7b-0377-4b62-a3b4-44ade2b68d61">
