### PR TITLE
게시글 상세 페이지 수정 및 에러 수정 (#28)

### DIFF
--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/domain/RecruitmentPost.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/domain/RecruitmentPost.java
@@ -39,7 +39,7 @@ public class RecruitmentPost {
     private String title;
 
     @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String content;
 
     @OneToMany(mappedBy = "post", cascade = ALL, orphanRemoval = true)

--- a/Frontend/editor-recruitment-front/package-lock.json
+++ b/Frontend/editor-recruitment-front/package-lock.json
@@ -31,6 +31,7 @@
         "react-scripts": "5.0.1",
         "react-select": "^5.8.0",
         "react-slick": "^0.30.2",
+        "react-toastify": "^10.0.5",
         "slick-carousel": "^1.8.1",
         "styled-components": "^6.1.11",
         "typescript": "^4.9.5",
@@ -7263,6 +7264,14 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
       }
@@ -20320,6 +20329,18 @@
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -29325,6 +29346,11 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       }
+    },
+    "clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
     },
     "co": {
       "version": "4.6.0",
@@ -38675,6 +38701,14 @@
         "json2mq": "^0.2.0",
         "lodash.debounce": "^4.0.8",
         "resize-observer-polyfill": "^1.5.0"
+      }
+    },
+    "react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "requires": {
+        "clsx": "^2.1.0"
       }
     },
     "react-transition-group": {

--- a/Frontend/editor-recruitment-front/package.json
+++ b/Frontend/editor-recruitment-front/package.json
@@ -26,6 +26,7 @@
     "react-scripts": "5.0.1",
     "react-select": "^5.8.0",
     "react-slick": "^0.30.2",
+    "react-toastify": "^10.0.5",
     "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.11",
     "typescript": "^4.9.5",

--- a/Frontend/editor-recruitment-front/src/App.tsx
+++ b/Frontend/editor-recruitment-front/src/App.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import 'react-toastify/dist/ReactToastify.css';
 import MainPage from './pages/MainPage';
 import CreatePostPage from './pages/recruitment/CreatePostPage';
 import MyProfilePage from './pages/MyProfilePage';
@@ -8,16 +9,22 @@ import JobsPage from './pages/recruitment/JobsPage';
 import WorkersPage from './pages/recruitment/WorkersPage';
 import CommunityPage from './pages/community/CommunityPage';
 import CommunityPostDetailPage from './pages/community/CommunityPostDetailPage';
-import CreateCommunityPostPage from './pages/community/CreateCommunityPostPage'; // 새로 추가
+import CreateCommunityPostPage from './pages/community/CreateCommunityPostPage';
 import GoogleAuthRedirectHandler from './components/GoogleAuthRedirectHandler';
 import PartnerMatchingPage from './pages/PartnerMatchingPage';
 import PostDetailPage from './pages/recruitment/PostDetailPage';
 import MyPostsPage from './pages/MyPostsPage';
+import EditPostPage from './pages/recruitment/EditPostPage';
 import './App.css';
+
+const ToastContainer = lazy(() => import('react-toastify').then(module => ({ default: module.ToastContainer })));
 
 const App = () => {
     return (
         <Router>
+            <Suspense fallback={<div>Loading...</div>}>
+                <ToastContainer position="top-right" autoClose={3000} hideProgressBar={false} newestOnTop={false} closeOnClick rtl={false} pauseOnFocusLoss draggable pauseOnHover />
+            </Suspense>
             <Routes>
                 <Route path="/" element={<MainPage />}>
                     <Route index element={<PostsPage />} />
@@ -32,6 +39,7 @@ const App = () => {
                     <Route path="match" element={<PartnerMatchingPage />} />
                     <Route path="myposts" element={<MyPostsPage />} />
                     <Route path="/post/:postId" element={<PostDetailPage />} />
+                    <Route path="/post/edit/:postId" element={<EditPostPage />} />
                 </Route>
             </Routes>
         </Router>

--- a/Frontend/editor-recruitment-front/src/components/MyProfile.tsx
+++ b/Frontend/editor-recruitment-front/src/components/MyProfile.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import '../styles/MyProfile.css';
 import { formatNumber } from '../utils/FormatNumber';
+import { useToast } from '../hooks/useToast';
 import premierProIcon from '../assets/premierProIcon';
 import photoshopIcon from '../assets/photoshopIcon';
 import afterEffectsIcon from '../assets/afterEffectsIcon';
@@ -47,6 +48,7 @@ const MyProfile = () => {
     const [introduction, setIntroduction] = useState('');
     const [imageUrl, setImageUrl] = useState('https://ifh.cc/g/q2ZvDd.jpg');
     const [isEditing, setIsEditing] = useState(false);
+    const { showSuccessToast, showErrorToast } = useToast();
 
     const handleImageUpload = useCallback(() => {
         console.log('Image upload button clicked'); // 디버깅용 로그
@@ -80,11 +82,11 @@ const MyProfile = () => {
                     console.log('New image URL:', imageUrl); // 디버깅용 로그
                 } catch (error) {
                     console.error('이미지 업로드 실패:', error);
-                    alert('프로필 이미지 업로드에 실패했습니다.');
+                    showErrorToast('프로필 이미지 업로드에 실패했습니다.');
                 }
             }
         };
-    }, []);
+    }, [showErrorToast]);
 
     useEffect(() => {
         fetchProfileData();
@@ -136,13 +138,13 @@ const MyProfile = () => {
                 },
                 withCredentials: true,
             });
-            alert('프로필이 성공적으로 저장되었습니다.');
+            showSuccessToast('프로필이 성공적으로 저장되었습니다.');
             setIsEditing(false);
             // 페이지 새로고침
             window.location.reload();
         } catch (error) {
             console.error('프로필 저장 중 오류가 발생했습니다:', error);
-            alert('프로필 저장에 실패했습니다.');
+            showErrorToast('프로필 저장에 실패했습니다.');
         }
     };
 

--- a/Frontend/editor-recruitment-front/src/components/RecruitmentPostList.tsx
+++ b/Frontend/editor-recruitment-front/src/components/RecruitmentPostList.tsx
@@ -47,18 +47,29 @@ const RecruitmentPostItem: React.FC<RecruitmentPostItemProps> = ({ post, variant
     const getPaymentString = (payments: PaymentDTO[]) => {
         if (payments.length === 0) return '정보 없음';
         const payment = payments[0];
-        if (payment.type === 'MONTHLY_SALARY') {
-            return `월 ${payment.amount.toLocaleString()}원`;
-        } else if (payment.type === 'PER_HOUR') {
-            return `분당 ${payment.amount.toLocaleString()}원`;
+        const formattedAmount = payment.amount.toLocaleString('ko-KR', { maximumFractionDigits: 0 });
+        switch (payment.type) {
+            case 'MONTHLY_SALARY':
+                return `월 ${formattedAmount}원`;
+            case 'PER_HOUR':
+                return `분당 ${formattedAmount}원`;
+            case 'PER_PROJECT':
+                return `건당 ${formattedAmount}원`;
+            case 'NEGOTIABLE':
+                return '협의 가능';
+            default:
+                return '정보 없음';
         }
-        return '정보 없음';
     };
 
     const truncateContent = (content: string, maxLength: number) => {
         const textContent = extractTextFromHTML(content);
         if (textContent.length <= maxLength) return textContent;
         return textContent.slice(0, maxLength) + '...';
+    };
+
+    const formatNumber = (num: number) => {
+        return num.toLocaleString('ko-KR', { maximumFractionDigits: 0 });
     };
 
     return (
@@ -80,7 +91,7 @@ const RecruitmentPostItem: React.FC<RecruitmentPostItemProps> = ({ post, variant
                 <h3 className="post-title">{post.title}</h3>
                 {variant === 'jobs' && (
                     <p className="post-description">
-                        {truncateContent(post.content, 20)}
+                        {truncateContent(post.content, 100)}
                     </p>
                 )}
                 {variant === 'main' && (
@@ -98,7 +109,7 @@ const RecruitmentPostItem: React.FC<RecruitmentPostItemProps> = ({ post, variant
                         </div>
                         <div className="detail-item subscribers">
                             <span className="detail-label">구독자 수</span>
-                            <span className="detail-value">{post.recruitmentPostDetailsRes.maxSubs.toLocaleString()}명</span>
+                            <span className="detail-value">{formatNumber(post.recruitmentPostDetailsRes.maxSubs)}명</span>
                         </div>
                         <div className="detail-item workload">
                             <span className="detail-label">작업 갯수</span>

--- a/Frontend/editor-recruitment-front/src/hooks/useToast.tsx
+++ b/Frontend/editor-recruitment-front/src/hooks/useToast.tsx
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+import { toast, ToastOptions } from 'react-toastify';
+
+const defaultOptions: ToastOptions = {
+  position: "top-right",
+  autoClose: 3000,
+  hideProgressBar: false,
+  closeOnClick: true,
+  pauseOnHover: true,
+  draggable: true,
+};
+
+export const useToast = () => {
+  const showSuccessToast = useCallback((message: string, options?: ToastOptions) => {
+    toast.success(message, { ...defaultOptions, ...options });
+  }, []);
+
+  const showErrorToast = useCallback((message: string, options?: ToastOptions) => {
+    toast.error(message, { ...defaultOptions, ...options });
+  }, []);
+
+  const showInfoToast = useCallback((message: string, options?: ToastOptions) => {
+    toast.info(message, { ...defaultOptions, ...options });
+  }, []);
+
+  const showWarningToast = useCallback((message: string, options?: ToastOptions) => {
+    toast.warning(message, { ...defaultOptions, ...options });
+  }, []);
+
+  return {
+    showSuccessToast,
+    showErrorToast,
+    showInfoToast,
+    showWarningToast,
+  };
+};

--- a/Frontend/editor-recruitment-front/src/pages/community/CommunityPage.tsx
+++ b/Frontend/editor-recruitment-front/src/pages/community/CommunityPage.tsx
@@ -33,7 +33,6 @@ const CommunityPage: React.FC = () => {
             try {
                 const response = await axios.get<ApiResponse>('http://localhost:8080/api/community/posts');
                 setPosts(response.data.data);
-                // 인기 게시글은 조회수 기준으로 상위 5개를 선택합니다.
                 const sortedPosts = [...response.data.data].sort((a, b) => b.viewCount - a.viewCount);
                 setPopularPosts(sortedPosts.slice(0, 5));
             } catch (error) {

--- a/Frontend/editor-recruitment-front/src/pages/recruitment/CreatePostPage.tsx
+++ b/Frontend/editor-recruitment-front/src/pages/recruitment/CreatePostPage.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import PostEditor from '../../components/PostEditor';
 import { useNavigate } from 'react-router-dom';
+import { useToast } from '../../hooks/useToast';
+
+interface ExceptionResponse {
+    status: number;
+    message: string;
+}
 
 const CreatePostPage = () => {
     const navigate = useNavigate();
+    const { showSuccessToast, showErrorToast, showWarningToast } = useToast();
 
     const handlePostSubmit = async (title: string, content: string, images: string[], tagNames: string[], payments: any[], recruitmentPostDetailsReq: any) => {
         try {
@@ -31,12 +38,33 @@ const CreatePostPage = () => {
             });
 
             if (response.status === 200) {
-                alert('게시글이 성공적으로 작성되었습니다.');
+                showSuccessToast('게시글이 성공적으로 작성되었습니다.');
                 navigate('/');
             }
         } catch (error) {
+            if (axios.isAxiosError(error)) {
+                const axiosError = error as AxiosError<ExceptionResponse>;
+                if (axiosError.response) {
+                    if (axiosError.response.status === 400) {
+                        const errorMessage = axiosError.response.data?.message || '모든 내용을 채워주십시오.';
+                        showWarningToast(errorMessage);
+                    } else if (axiosError.response.status === 401) {
+                        showErrorToast('로그인 세션이 만료되었습니다. 다시 로그인해 주세요.');
+                        sessionStorage.removeItem('access-token');
+                        navigate('/login');
+                    } else {
+                        showErrorToast('게시글 작성 중 오류가 발생했습니다.');
+                    }
+                    console.error('에러 상세 정보:', axiosError.response.data);
+                } else if (axiosError.request) {
+                    showErrorToast('서버로부터 응답을 받지 못했습니다. 네트워크 연결을 확인해주세요.');
+                } else {
+                    showErrorToast('요청 설정 중 오류가 발생했습니다.');
+                }
+            } else {
+                showErrorToast('알 수 없는 오류가 발생했습니다.');
+            }
             console.error('게시글 작성 중 오류가 발생했습니다.', error);
-            alert('게시글 작성 중 오류가 발생했습니다.');
         }
     };
 

--- a/Frontend/editor-recruitment-front/src/pages/recruitment/EditPostPage.tsx
+++ b/Frontend/editor-recruitment-front/src/pages/recruitment/EditPostPage.tsx
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import PostEditor from '../../components/PostEditor';
+import { useToast } from '../../hooks/useToast';
+
+const EditPostPage: React.FC = () => {
+    const { postId } = useParams<{ postId: string }>();
+    const [initialData, setInitialData] = useState<any>(null);
+    const [loading, setLoading] = useState(true);
+    const navigate = useNavigate();
+    const { showSuccessToast, showErrorToast } = useToast();
+
+    useEffect(() => {
+        const fetchPostData = async () => {
+            try {
+                const accessToken = sessionStorage.getItem('access-token');
+                if (!accessToken) {
+                    throw new Error('액세스 토큰이 없습니다.');
+                }
+
+                const response = await axios.get(`http://localhost:8080/api/recruitment/posts/${postId}`, {
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                        'Content-Type': 'application/json',
+                    },
+                    withCredentials: true
+                });
+                setInitialData(response.data.data);
+                setLoading(false);
+            } catch (error) {
+                console.error('게시글 데이터를 불러오는데 실패했습니다.', error);
+                showErrorToast('게시글 데이터를 불러오는데 실패했습니다.');
+                navigate('/');
+            }
+        };
+
+        fetchPostData();
+    }, [postId, navigate, showErrorToast]);
+
+    const handlePostSubmit = async (title: string, content: string, images: string[], tagNames: string[], payments: any[], recruitmentPostDetailsReq: any) => {
+        try {
+            const accessToken = sessionStorage.getItem('access-token');
+            const refreshToken = sessionStorage.getItem('refresh-token');
+            if (!accessToken || !refreshToken) {
+                throw new Error('토큰이 없습니다.');
+            }
+
+            const requestData = {
+                title,
+                content,
+                images,
+                tagNames,
+                payments,
+                recruitmentPostDetailsReq,
+            };
+
+            await axios.put(`http://localhost:8080/api/recruitment/posts/${postId}`, requestData, {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    'Refresh-Token': refreshToken,
+                    'Content-Type': 'application/json',
+                },
+            });
+
+            showSuccessToast('게시글이 성공적으로 수정되었습니다.');
+            navigate(`/post/${postId}`);
+        } catch (error) {
+            console.error('게시글 수정 중 오류가 발생했습니다.', error);
+            showErrorToast('게시글 수정 중 오류가 발생했습니다.');
+        }
+    };
+
+    if (loading) {
+        return <div>로딩 중...</div>;
+    }
+
+    return (
+        <div>
+            <h1>게시글 수정</h1>
+            <PostEditor onSubmit={handlePostSubmit} initialData={initialData} />
+        </div>
+    );
+};
+
+export default EditPostPage;

--- a/Frontend/editor-recruitment-front/src/styles/PostDetailPage.css
+++ b/Frontend/editor-recruitment-front/src/styles/PostDetailPage.css
@@ -47,6 +47,7 @@
     font-size: 2.5rem;
     color: #333;
     margin-bottom: 15px;
+    clear: both;
 }
 
 .post-detail-page .post-meta {
@@ -172,4 +173,70 @@
     color: #666;
     background-color: #f8f8f8;
     border-radius: 15px;
+}
+
+.post-content {
+    max-width: 100%;
+    overflow: hidden;
+}
+
+.content-images {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.post-image {
+    max-width: 100%;
+    height: auto;
+    object-fit: cover;
+    border-radius: 8px;
+}
+
+.content-text img {
+    max-width: 100%;
+    height: auto;
+    object-fit: cover;
+    border-radius: 8px;
+}
+
+.post-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 20px;
+}
+
+.post-actions {
+    display: flex;
+    gap: 10px;
+}
+
+.action-button {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 20px;
+    cursor: pointer;
+    font-weight: bold;
+    font-size: 0.9rem;
+    transition: all 0.3s ease;
+}
+
+.edit-button {
+    background-color: #4CAF50;
+    color: white;
+}
+
+.edit-button:hover {
+    background-color: #45a049;
+}
+
+.delete-button {
+    background-color: #f44336;
+    color: white;
+}
+
+.delete-button:hover {
+    background-color: #da190b;
 }


### PR DESCRIPTION
## 게시글 상세 페이지 수정 및 에러 수정 (#28)
- PostDetailPage 컴포넌트 수정:
  - RecruitmentPostRes 인터페이스에 isAuthor 필드 추가
  - 서버에서 판단한 작성자 여부(isAuthor)에 따라 수정 및 삭제 버튼 표시 로직 변경
- MyProfile 컴포넌트 개선:
  - useToast 훅 import 및 사용
  - 이미지 업로드 실패 시 alert 대신 showErrorToast 사용
  - 프로필 저장 성공 시 showSuccessToast, 실패 시 showErrorToast 사용
  - handleImageUpload 함수의 의존성 배열에 showErrorToast 추가
- 전반적인 코드 개선:
  - 불필요한 주석 및 콘솔 로그 제거
  - 코드 가독성 향상을 위한 minor 리팩토링

![image](https://github.com/user-attachments/assets/dde86d7f-9119-4a39-8873-f067afcf64f6)

![image](https://github.com/user-attachments/assets/fb513a47-a180-41d4-a3b0-4e42f944d670)

