### PR TITLE
헤더바 및 커뮤니티 & 구인 검색 기능 리팩토링 (#46)

### DIFF
--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/dao/CommunityPostRepository.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/dao/CommunityPostRepository.java
@@ -2,8 +2,12 @@ package com.pyeondongbu.editorrecruitment.domain.community.dao;
 
 import com.pyeondongbu.editorrecruitment.domain.community.domain.CommunityPost;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.domain.RecruitmentPost;
+import com.pyeondongbu.editorrecruitment.domain.tag.domain.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,5 +16,8 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
     Optional<CommunityPost> findByMemberIdAndId(final Long memberId, final Long postId);
 
     List<CommunityPost> findByMemberId(final Long memberId);
+
+    @Query("SELECT DISTINCT cp FROM CommunityPost cp JOIN cp.tags t WHERE t.name IN :tagNames")
+    List<CommunityPost> findByTagNames(@Param("tagNames") Collection<String> tagNames);
 
 }

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/domain/CommunityPost.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/domain/CommunityPost.java
@@ -2,6 +2,8 @@ package com.pyeondongbu.editorrecruitment.domain.community.domain;
 
 import com.pyeondongbu.editorrecruitment.domain.community.dto.request.CommunityPostReq;
 import com.pyeondongbu.editorrecruitment.domain.member.domain.Member;
+import com.pyeondongbu.editorrecruitment.domain.tag.domain.Tag;
+import com.pyeondongbu.editorrecruitment.global.validation.PostValidationUtils;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,6 +13,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -39,6 +43,14 @@ public class CommunityPost {
     @LastModifiedDate
     private LocalDateTime modifiedAt;
 
+    @ManyToMany
+    @JoinTable(
+            name = "community_post_tag",
+            joinColumns = @JoinColumn(name = "community_post_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private Set<Tag> tags = new HashSet<>();
+
     @Column(columnDefinition = "integer default 0", nullable = false)
     private int viewCount;
 
@@ -46,10 +58,12 @@ public class CommunityPost {
     public CommunityPost(
             final String title,
             final String content,
+            final Set<Tag> tags,
             final Member member
     ) {
         this.title = title;
         this.content = content;
+        this.tags = tags != null ? tags : new HashSet<>();
         this.member = member;
         this.createdAt = LocalDateTime.now();
         this.modifiedAt = LocalDateTime.now();
@@ -58,19 +72,23 @@ public class CommunityPost {
     public static CommunityPost of(
             final String title,
             final String content,
+            final Set<Tag> tags,
             final Member member
     ) {
         return CommunityPost.builder()
                 .title(title)
                 .content(content)
+                .tags(tags)
                 .member(member)
                 .build();
     }
 
     public CommunityPost update(
-            final CommunityPostReq req
+            final CommunityPostReq req,
+            final PostValidationUtils.ValidationResult validationResult
     ) {
         this.title = req.getTitle();
+        this.tags = validationResult.tags();
         this.content = req.getContent();
         this.modifiedAt = LocalDateTime.now();
         return this;

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/dto/request/CommunityPostReq.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/dto/request/CommunityPostReq.java
@@ -1,9 +1,12 @@
 package com.pyeondongbu.editorrecruitment.domain.community.dto.request;
 
 import com.pyeondongbu.editorrecruitment.domain.community.domain.CommunityPost;
+import com.pyeondongbu.editorrecruitment.domain.tag.domain.Tag;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -17,6 +20,9 @@ public class CommunityPostReq {
 
     @NotBlank(message = "내용은 공백이 될 수 없습니다.")
     private String content;
+
+    @Size(min = 1, max = 4, message = "태그는 1개 이상 4개 이하로 선택해야 합니다.")
+    private List<String> tagNames;
 
     public static CommunityPostReq of(final CommunityPost communityPost) {
         return CommunityPostReq.builder()

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/dto/response/CommunityPostRes.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/dto/response/CommunityPostRes.java
@@ -1,9 +1,13 @@
 package com.pyeondongbu.editorrecruitment.domain.community.dto.response;
 
 import com.pyeondongbu.editorrecruitment.domain.community.domain.CommunityPost;
+import com.pyeondongbu.editorrecruitment.domain.recruitment.domain.RecruitmentPost;
+import com.pyeondongbu.editorrecruitment.domain.tag.domain.Tag;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -15,6 +19,7 @@ public class CommunityPostRes {
     private String title;
     private String content;
     private String memberName;
+    private List<String> tagNames;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private int viewCount;
@@ -24,7 +29,6 @@ public class CommunityPostRes {
      * 게시글 하나 조회 시
      */
 
-
     public static CommunityPostRes from(
             final CommunityPost post,
             final Boolean isAuthor
@@ -33,6 +37,7 @@ public class CommunityPostRes {
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
+                .tagNames(getTagsNameList(post))
                 .memberName(post.getMember().getNickname())
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())
@@ -53,10 +58,17 @@ public class CommunityPostRes {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .memberName(post.getMember().getNickname())
+                .tagNames(getTagsNameList(post))
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())
                 .viewCount(post.getViewCount())
                 .build();
+    }
+
+    private static List<String> getTagsNameList(CommunityPost post) {
+        return post.getTags().stream()
+                .map(Tag::getName)
+                .collect(Collectors.toList());
     }
 
 }

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/presentation/CommunityPostSearchController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/presentation/CommunityPostSearchController.java
@@ -1,0 +1,31 @@
+package com.pyeondongbu.editorrecruitment.domain.community.presentation;
+
+import com.pyeondongbu.editorrecruitment.domain.community.dto.response.CommunityPostRes;
+import com.pyeondongbu.editorrecruitment.domain.community.service.CommunityPostService;
+import com.pyeondongbu.editorrecruitment.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/community/posts/search")
+@RequiredArgsConstructor
+public class CommunityPostSearchController {
+
+    private final CommunityPostService communityPostService;
+
+    @GetMapping("/by-tags")
+    public ResponseEntity<ApiResponse<List<CommunityPostRes>>> searchPosts(
+            @RequestParam(name = "tagNames", required = false) List<String> tagNames
+    ) {
+        List<CommunityPostRes> posts = communityPostService.searchPostsByTags(tagNames);
+        return ResponseEntity.ok(
+                ApiResponse.success(posts, 200)
+        );
+    }
+}

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/service/CommunityPostService.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/community/service/CommunityPostService.java
@@ -16,6 +16,8 @@ public interface CommunityPostService {
 
     List<CommunityPostRes> listPosts();
 
+    List<CommunityPostRes> searchPostsByTags(List<String> tagNames);
+
     CommunityPostRes update(final Long postId, final CommunityPostReq request, final Long memberId);
 
     void deletePost(final Long postId, final Long memberId);

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dto/response/RecruitmentPostRes.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/dto/response/RecruitmentPostRes.java
@@ -32,6 +32,10 @@ public class RecruitmentPostRes {
 
     private Boolean isAuthor;
 
+    /**
+     * 게시글 하나 조회 시
+     */
+
     public static RecruitmentPostRes from(
             final RecruitmentPost post,
             final Boolean isAuthor
@@ -51,6 +55,10 @@ public class RecruitmentPostRes {
                 .isAuthor(isAuthor)
                 .build();
     }
+
+    /**
+     * 게시글 전체 조회 시
+     */
 
     public static RecruitmentPostRes from(
             final RecruitmentPost post

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostServiceImpl.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/recruitment/service/RecruitmentPostServiceImpl.java
@@ -57,7 +57,6 @@ public class RecruitmentPostServiceImpl implements RecruitmentPostService {
         return createOrUpdatePost(post, req, validationResult);
     }
 
-    // To-DO 현재 게시글 작성자인지 확인하는 거 추가 Response에 isAuthor 추가
     @Override
     @Transactional(readOnly = true)
     @DistributedLock

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/validation/PostValidationUtils.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/global/validation/PostValidationUtils.java
@@ -2,6 +2,7 @@ package com.pyeondongbu.editorrecruitment.global.validation;
 
 import com.pyeondongbu.editorrecruitment.domain.common.dao.PostViewRepository;
 import com.pyeondongbu.editorrecruitment.domain.common.domain.PostView;
+import com.pyeondongbu.editorrecruitment.domain.community.dto.request.CommunityPostReq;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.domain.Payment;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.dto.PaymentDTO;
 import com.pyeondongbu.editorrecruitment.domain.recruitment.dto.request.RecruitmentPostReq;
@@ -62,6 +63,27 @@ public class PostValidationUtils {
         return new ValidationResult(tags, payment);
     }
 
+    // To-DO 나중에 리팩토링 필요할 거 같은 부분, 마음에 안 듬
+    public ValidationResult validateCommunityPostReq(CommunityPostReq postReq) {
+        Set<ConstraintViolation<CommunityPostReq>> violations = validator.validate(postReq);
+
+        if (!violations.isEmpty()) {
+            throw new BadRequestException(INVALID_POST_DETAILS);
+        }
+
+
+        for(String s : postReq.getTagNames()) {
+            log.info("태그 이름 = " + s);
+        }
+
+        Set<Tag> tags = validateTagNames(postReq.getTagNames());
+
+        return new ValidationResult(tags, null);
+    }
+
+
+
+
     private Set<Tag> validateTagNames(List<String> tagNames) {
         if (tagNames == null || tagNames.isEmpty()) {
             throw new BadRequestException(INVALID_TAG_NAME);
@@ -102,4 +124,5 @@ public class PostValidationUtils {
 
     public record ValidationResult(Set<Tag> tags, Payment payment) {
     }
+
 }

--- a/Frontend/editor-recruitment-front/src/App.tsx
+++ b/Frontend/editor-recruitment-front/src/App.tsx
@@ -15,6 +15,7 @@ import PartnerMatchingPage from './pages/PartnerMatchingPage';
 import PostDetailPage from './pages/recruitment/PostDetailPage';
 import MyPostsPage from './pages/MyPostsPage';
 import EditPostPage from './pages/recruitment/EditPostPage';
+import SearchResultsPage from './pages/SearchResultsPage';
 import './App.css';
 
 const ToastContainer = lazy(() => import('react-toastify').then(module => ({ default: module.ToastContainer })));
@@ -40,6 +41,7 @@ const App = () => {
                     <Route path="myposts" element={<MyPostsPage />} />
                     <Route path="/post/:postId" element={<PostDetailPage />} />
                     <Route path="/post/edit/:postId" element={<EditPostPage />} />
+                    <Route path="/search" element={<SearchResultsPage />} />
                 </Route>
             </Routes>
         </Router>

--- a/Frontend/editor-recruitment-front/src/components/CommunityPostEditor.tsx
+++ b/Frontend/editor-recruitment-front/src/components/CommunityPostEditor.tsx
@@ -4,26 +4,30 @@ import 'react-quill/dist/quill.snow.css';
 import '../styles/CommunityPostEditor.css';
 
 interface CommunityPostEditorProps {
-    onSubmit: (title: string, content: string, tag: string) => void;
+    onSubmit: (title: string, content: string, tags: string[]) => void;
 }
 
 const CommunityPostEditor: React.FC<CommunityPostEditorProps> = ({ onSubmit }) => {
     const [title, setTitle] = useState('');
     const [content, setContent] = useState('');
-    const [tag, setTag] = useState('');
+    const [selectedTags, setSelectedTags] = useState<string[]>([]);
     const [tagError, setTagError] = useState(false);
     const quillRef = useRef<ReactQuill>(null);
 
     const handleSubmit = () => {
-        if (!tag) {
+        if (selectedTags.length === 0) {
             setTagError(true);
             return;
         }
-        onSubmit(title, content, tag);
+        onSubmit(title, content, selectedTags);
     };
 
-    const handleTagSelect = (selectedTag: string) => {
-        setTag(selectedTag);
+    const handleTagToggle = (tag: string) => {
+        setSelectedTags(prevTags =>
+            prevTags.includes(tag)
+                ? prevTags.filter(t => t !== tag)
+                : [...prevTags, tag]
+        );
         setTagError(false);
     };
 
@@ -64,19 +68,19 @@ const CommunityPostEditor: React.FC<CommunityPostEditorProps> = ({ onSubmit }) =
                     className="community-post-editor__content-input"
                 />
                 <div className="community-post-editor__tag-selection">
-                    <h3>태그 선택</h3>
+                    <h3>태그 선택 (1개 이상)</h3>
                     <div className="community-post-editor__tag-buttons">
                         {tags.map((tagOption) => (
                             <button
                                 key={tagOption}
-                                className={`community-post-editor__tag-button ${tag === tagOption ? 'active' : ''}`}
-                                onClick={() => handleTagSelect(tagOption)}
+                                className={`community-post-editor__tag-button ${selectedTags.includes(tagOption) ? 'active' : ''}`}
+                                onClick={() => handleTagToggle(tagOption)}
                             >
                                 {tagOption}
                             </button>
                         ))}
                     </div>
-                    {tagError && <p className="tag-error-message">태그를 선택해 주세요.</p>}
+                    {tagError && <p className="tag-error-message">태그를 1개 이상 선택해 주세요.</p>}
                 </div>
                 <div className="button-container">
                     <button onClick={handleSubmit} className="community-post-editor__submit-button">

--- a/Frontend/editor-recruitment-front/src/components/Header.tsx
+++ b/Frontend/editor-recruitment-front/src/components/Header.tsx
@@ -107,7 +107,7 @@ const Header = () => {
 
     const handleSearch = () => {
         if (searchQuery.trim()) {
-            navigate(`/search?query=${searchQuery}`);
+            navigate(`/search?query=${encodeURIComponent(searchQuery)}`);
         }
     };
 

--- a/Frontend/editor-recruitment-front/src/pages/SearchResultsPage.tsx
+++ b/Frontend/editor-recruitment-front/src/pages/SearchResultsPage.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import '../styles/SearchResultsPage.css';
+import { extractTextFromHTML } from '../utils/TextExtractor';
+
+interface PaymentDTO {
+    type: string;
+    amount: number;
+}
+
+interface RecruitmentPostDetailsRes {
+    maxSubs: number;
+    videoTypes: string[];
+    skills: string[];
+    remarks: string;
+    weeklyWorkload: string;
+}
+
+interface SearchResult {
+    id: number;
+    title: string;
+    content: string;
+    memberName: string;
+    createdAt: string;
+    modifiedAt: string;
+    viewCount: number;
+    imageUrl: string;
+    tagNames: string[];
+    payment: PaymentDTO;
+    recruitmentPostDetailsRes: RecruitmentPostDetailsRes;
+}
+
+const SearchResultsPage: React.FC = () => {
+    const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+    const [loading, setLoading] = useState(true);
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const searchQuery = new URLSearchParams(location.search).get('query');
+        if (searchQuery) {
+            fetchSearchResults(searchQuery);
+        }
+    }, [location.search]);
+
+    const fetchSearchResults = async (query: string) => {
+        setLoading(true);
+        try {
+            const response = await axios.get(`http://localhost:8080/api/recruitment/posts/search/by-details?title=${encodeURIComponent(query)}`);
+            setSearchResults(response.data.data);
+        } catch (error) {
+            console.error('검색 결과를 가져오는데 실패했습니다:', error);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const getPaymentString = (payment: PaymentDTO) => {
+        if (!payment) return '정보 없음';
+        const formattedAmount = payment.amount.toLocaleString('ko-KR', { maximumFractionDigits: 0 });
+        switch (payment.type) {
+            case 'MONTHLY_SALARY':
+                return `월 ${formattedAmount}원`;
+            case 'PER_HOUR':
+                return `분당 ${formattedAmount}원`;
+            case 'PER_PROJECT':
+                return `건당 ${formattedAmount}원`;
+            case 'NEGOTIABLE':
+                return '협의 가능';
+            default:
+                return '정보 없음';
+        }
+    };
+
+    const truncateContent = (content: string, maxLength: number) => {
+        const textContent = extractTextFromHTML(content);
+        if (textContent.length <= maxLength) return textContent;
+        return textContent.slice(0, maxLength) + '...';
+    };
+
+    const formatNumber = (num: number) => {
+        return num.toLocaleString('ko-KR', { maximumFractionDigits: 0 });
+    };
+
+    if (loading) {
+        return <div className="loading">검색 중...</div>;
+    }
+
+    return (
+        <div className="search-results-page">
+            <h1 className="search-results-title">검색 결과</h1>
+            <div className="search-results-list">
+                {searchResults.length > 0 ? (
+                    searchResults.map((post) => (
+                        <div key={post.id} className="recruitment-post-item" onClick={() => navigate(`/post/${post.id}`)}>
+                            <div className="post-image">
+                                {post.imageUrl && (
+                                    <img 
+                                        src={post.imageUrl} 
+                                        alt={`게시글 이미지`} 
+                                        loading="lazy"
+                                        onError={(e) => {
+                                            const target = e.target as HTMLImageElement;
+                                            target.src = '/path/to/placeholder-image.jpg';
+                                        }}
+                                    />
+                                )}
+                            </div>
+                            <div className="post-content">
+                                <h3 className="post-title">{post.title}</h3>
+                                <p className="post-description">
+                                    {truncateContent(post.content, 100)}
+                                </p>
+                                <div className="post-details">
+                                    <div className="detail-item payment">
+                                        <span className="detail-label">페이</span>
+                                        <span className="detail-value">{getPaymentString(post.payment)}</span>
+                                    </div>
+                                    <div className="detail-item subscribers">
+                                        <span className="detail-label">구독자 수</span>
+                                        <span className="detail-value">{formatNumber(post.recruitmentPostDetailsRes.maxSubs)}명</span>
+                                    </div>
+                                    <div className="detail-item workload">
+                                        <span className="detail-label">작업 갯수</span>
+                                        <span className="detail-value">{post.recruitmentPostDetailsRes.weeklyWorkload}개</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    ))
+                ) : (
+                    <div className="no-results">검색 결과가 없습니다.</div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default SearchResultsPage;

--- a/Frontend/editor-recruitment-front/src/pages/community/CommunityPage.tsx
+++ b/Frontend/editor-recruitment-front/src/pages/community/CommunityPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import '../../styles/CommunityPage.css';
 import { AiOutlineSearch } from 'react-icons/ai';
+import { extractTextFromHTML } from '../../utils/TextExtractor';
 
 interface CommunityPost {
     id: number;
@@ -31,7 +32,16 @@ const CommunityPage: React.FC = () => {
     useEffect(() => {
         const fetchPosts = async () => {
             try {
-                const response = await axios.get<ApiResponse>('http://localhost:8080/api/community/posts');
+                let url = 'http://localhost:8080/api/community/posts';
+                let response;
+
+                if (selectedCategory === 'all') {
+                    response = await axios.get<ApiResponse>(url);
+                } else {
+                    url = `${url}/search/by-tags?tagNames=${selectedCategory}`;
+                    response = await axios.get<ApiResponse>(url);
+                }
+
                 setPosts(response.data.data);
                 const sortedPosts = [...response.data.data].sort((a, b) => b.viewCount - a.viewCount);
                 setPopularPosts(sortedPosts.slice(0, 5));
@@ -41,7 +51,7 @@ const CommunityPage: React.FC = () => {
         };
 
         fetchPosts();
-    }, []);
+    }, [selectedCategory]);
 
     const categories = ['편집', '유튜버', '썸네일러', '모델링'];
 
@@ -78,7 +88,7 @@ const CommunityPage: React.FC = () => {
                     {popularPosts.map((post) => (
                         <div key={post.id} className="popular-post-item" onClick={() => handlePostClick(post.id)}>
                             <h4>{post.title}</h4>
-                            <p>{post.content.slice(0, 15)}...</p>
+                            <p>{extractTextFromHTML(post.content).slice(0, 15)}...</p>
                             <span className="popular-post-author">{post.memberName}</span>
                         </div>
                     ))}
@@ -126,7 +136,7 @@ const CommunityPage: React.FC = () => {
                                 onClick={() => handlePostClick(post.id)}
                             >
                                 <h3>{post.title}</h3>
-                                <p>{post.content}</p>
+                                <p>{extractTextFromHTML(post.content)}</p>
                                 <div className="post-info">
                                     <span className="post-author">{post.memberName}</span>
                                     <span className="post-date">{new Date(post.createdAt).toLocaleDateString()}</span>

--- a/Frontend/editor-recruitment-front/src/pages/community/CommunityPostDetailPage.tsx
+++ b/Frontend/editor-recruitment-front/src/pages/community/CommunityPostDetailPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
+import DOMPurify from 'dompurify';
 import '../../styles/CommunityPostDetailPage.css';
 
 interface CommunityPost {
@@ -53,6 +54,10 @@ const CommunityPostDetailPage: React.FC = () => {
         return date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' });
     };
 
+    const createMarkup = (html: string) => {
+        return { __html: DOMPurify.sanitize(html) };
+    };
+
     return (
         <div className="community-post-detail-page">
             <div className="post-header">
@@ -63,9 +68,7 @@ const CommunityPostDetailPage: React.FC = () => {
                     <span className="post-views">조회수: {post.viewCount}</span>
                 </div>
             </div>
-            <div className="post-content">
-                <p>{post.content}</p>
-            </div>
+            <div className="post-content" dangerouslySetInnerHTML={createMarkup(post.content)} />
         </div>
     );
 };

--- a/Frontend/editor-recruitment-front/src/pages/community/CreateCommunityPostPage.tsx
+++ b/Frontend/editor-recruitment-front/src/pages/community/CreateCommunityPostPage.tsx
@@ -6,7 +6,7 @@ import CommunityPostEditor from '../../components/CommunityPostEditor';
 const CreateCommunityPostPage: React.FC = () => {
     const navigate = useNavigate();
 
-    const handlePostSubmit = async (title: string, content: string, tag: string) => {
+    const handlePostSubmit = async (title: string, content: string, tags: string[]) => {
         try {
             const accessToken = sessionStorage.getItem('access-token');
             if (!accessToken) {
@@ -16,7 +16,7 @@ const CreateCommunityPostPage: React.FC = () => {
             const requestData = {
                 title,
                 content,
-                tag,
+                tagNames: tags, 
             };
 
             await axios.post('http://localhost:8080/api/community/posts', requestData, {
@@ -26,14 +26,14 @@ const CreateCommunityPostPage: React.FC = () => {
                 withCredentials: true,
             });
 
-            navigate('/community'); // 커뮤니티 탭으로 이동
+            navigate('/community');
         } catch (error) {
             console.error('게시글 작성 중 오류가 발생했습니다.', error);
             
             if (axios.isAxiosError(error) && error.response?.status === 401) {
                 alert('로그인 세션이 만료되었습니다. 다시 로그인해 주세요.');
-                sessionStorage.removeItem('access-token'); // 만료된 토큰 제거
-                navigate('/'); // 메인 페이지로 이동
+                sessionStorage.removeItem('access-token');
+                navigate('/');
             } else {
                 alert('게시글 작성 중 오류가 발생했습니다.');
             }

--- a/Frontend/editor-recruitment-front/src/styles/SearchResultsPage.css
+++ b/Frontend/editor-recruitment-front/src/styles/SearchResultsPage.css
@@ -1,0 +1,122 @@
+.search-results-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px;
+    width: 100%;
+    font-family: 'Pretendard', sans-serif;
+}
+
+.search-results-page .search-results-title {
+    font-size: 2rem;
+    margin-bottom: 20px;
+    align-self: flex-start;
+    margin-left: 100px;
+}
+
+.search-results-page .search-results-list {
+    width: 55%;
+    min-width: 1000px;
+    max-width: 1200px;
+}
+
+.search-results-page .loading {
+    font-size: 1.2rem;
+    color: #666;
+    text-align: center;
+    margin-top: 50px;
+}
+
+.search-results-page .recruitment-post-item {
+    display: flex;
+    width: 100%;
+    height: auto;
+    flex-direction: row;
+    padding: 1rem;
+    background-color: #fff;
+    border: 1px solid #e0e0e0;
+    border-radius: 25px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    cursor: pointer;
+    margin-bottom: 1rem;
+}
+
+.search-results-page .post-image {
+    display: flex;
+    width: 260px;
+    height: 140px;
+    margin-right: 1rem;
+}
+
+.search-results-page .post-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 20px;
+}
+
+.search-results-page .post-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.search-results-page .post-title {
+    font-size: 2rem;
+    margin: 0 0 0.5rem 0;
+    color: #333;
+}
+
+.search-results-page .post-description {
+    font-size: 16px;
+    color: #666;
+    margin-bottom: 1rem;
+}
+
+.search-results-page .post-details {
+    display: flex;
+    gap: 1rem;
+    justify-content: flex-start;
+}
+
+.search-results-page .detail-item {
+    display: flex;
+    align-items: center;
+    border-radius: 25px;
+    padding: 0.5rem 1rem;
+    background-color: #f0f0f0;
+}
+
+.search-results-page .detail-label {
+    font-size: 14px;
+    color: #fff;
+    padding: 0.25rem 0.5rem;
+    border-radius: 25px;
+    margin-right: 0.5rem;
+}
+
+.search-results-page .detail-value {
+    font-size: 14px;
+    font-weight: bold;
+    color: #333;
+}
+
+.search-results-page .detail-item.payment .detail-label {
+    background-color: #318F43;
+}
+
+.search-results-page .detail-item.subscribers .detail-label {
+    background-color: #4C88C3;
+}
+
+.search-results-page .detail-item.workload .detail-label {
+    background-color: #4C54C3;
+}
+
+.search-results-page .no-results {
+    font-size: 1.2rem;
+    color: #666;
+    text-align: center;
+    margin-top: 50px;
+}


### PR DESCRIPTION
## 헤더바 및 커뮤니티 & 구인 검색 기능 리팩토링 (#46)
- 헤더바에 통합 검색 기능 구현
  - 구인/구직 게시글 Title 기준 검색 로직 추가
  - 검색 결과 페이지 생성 및 스타일링
- 커뮤니티 검색 기능 개선
  - 카테고리 지정/미지정 상태에 따른 검색 로직 구현
  - 태그 기반 검색 기능 추가
- 작업 찾기 페이지 필터링 강화
  - 다중 필터 적용 가능한 검색 기능 구현 (스킬, 비디오 타입, 구독자 수 등)
- 작업자 찾기 페이지 필터링 개선
  - 작업자 프로필 기반 필터링 기능 구현 (스킬, 경력, 선호 작업 유형 등)



![image](https://github.com/user-attachments/assets/250d14c4-fb3a-4dbf-b65f-643e6afcce42)


![image](https://github.com/user-attachments/assets/4a79a79e-8d13-455b-82c8-01e3938ba62e)
