### PR TITLE
멤버 프로필 페이지 조회 기능 추가 (#49)

### DIFF
--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/dao/MemberRepository.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/dao/MemberRepository.java
@@ -33,4 +33,13 @@ public interface MemberRepository extends JpaRepository<Member, Long>, JpaSpecif
             "LEFT JOIN FETCH d.currentChannels c " +
             "WHERE m.id = :id")
     Optional<Member> findByIdWithDetails(@Param("id") Long id);
+
+    @Query("SELECT m FROM Member m " +
+            "LEFT JOIN FETCH m.details d " +
+            "LEFT JOIN FETCH d.skills s " +
+            "LEFT JOIN FETCH d.videoTypes v " +
+            "LEFT JOIN FETCH d.editedChannels e " +
+            "LEFT JOIN FETCH d.currentChannels c " +
+            "WHERE m.nickname = :nickname")
+    Optional<Member> findByNicknameWithDetails(@Param("nickname") String nickname);
 }

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/presentation/MemberController.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/presentation/MemberController.java
@@ -21,6 +21,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    //TO-DO: 나중에 없애도 될 거 같은 메서드임
     @GetMapping("/{memberId}")
     public ResponseEntity<ApiResponse<MemberRes>> findMember(
             @PathVariable("memberId") Long memberId

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/service/MemberService.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/service/MemberService.java
@@ -16,12 +16,12 @@ public interface MemberService {
     MyPageRes updateMyPage(final Long memberId, final MyPageReq myPageReq);
 
     List<MyPageRes> searchMembers(
-            Integer maxSubs,
-            String role,
-            List<String> skills,
-            List<String> videoTypes
+            final Integer maxSubs,
+            final String role,
+            final List<String> skills,
+            final List<String> videoTypes
     );
 
-    MyPageRes getPublicProfile(String nickname);
+    MyPageRes getPublicProfile(final String nickname);
 
 }

--- a/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/service/MemberServiceImpl.java
+++ b/Backend/editor-recruitment/src/main/java/com/pyeondongbu/editorrecruitment/domain/member/service/MemberServiceImpl.java
@@ -39,8 +39,8 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional(readOnly = true)
-        public MemberRes getMember(final Long memberId) {
-        Member member = memberRepository.findByIdWithDetails(memberId)
+    public MemberRes getMember(final Long memberId) {
+        final Member member = memberRepository.findByIdWithDetails(memberId)
                 .orElseThrow(() -> new AuthException(INVALID_USER_NAME));
 
         return new MemberRes(member);
@@ -67,7 +67,6 @@ public class MemberServiceImpl implements MemberService {
         return MyPageRes.from(updatedMember);
     }
 
-
     @Override
     @Transactional(readOnly = true)
     public List<MyPageRes> searchMembers(
@@ -89,8 +88,10 @@ public class MemberServiceImpl implements MemberService {
                 .collect(Collectors.toList());
     }
 
-    public MyPageRes getPublicProfile(String nickname) {
-        Member member = memberRepository.findByNickname(nickname)
+    @Override
+    @Transactional(readOnly = true)
+    public MyPageRes getPublicProfile(final String nickname) {
+        Member member = memberRepository.findByNicknameWithDetails(nickname)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_MEMBER_ID));
 
         return MyPageRes.from(member);

--- a/Frontend/editor-recruitment-front/src/App.tsx
+++ b/Frontend/editor-recruitment-front/src/App.tsx
@@ -14,6 +14,7 @@ import GoogleAuthRedirectHandler from './components/GoogleAuthRedirectHandler';
 import PartnerMatchingPage from './pages/PartnerMatchingPage';
 import PostDetailPage from './pages/recruitment/PostDetailPage';
 import MyPostsPage from './pages/MyPostsPage';
+import MemberProfilePage from './pages/member/MemberProfilePage';
 import EditPostPage from './pages/recruitment/EditPostPage';
 import SearchResultsPage from './pages/SearchResultsPage';
 import 'react-toastify/dist/ReactToastify.css';
@@ -44,6 +45,7 @@ const App: React.FC = () => {
           <Route path="/post/:postId" element={<PostDetailPage />} />
           <Route path="/post/edit/:postId" element={<EditPostPage />} />
           <Route path="/search" element={<SearchResultsPage />} />
+          <Route path="/member/:nickname" element={<MemberProfilePage />} />
         </Route>
       </Routes>
     </Router>

--- a/Frontend/editor-recruitment-front/src/components/ProfileSetupModal.tsx
+++ b/Frontend/editor-recruitment-front/src/components/ProfileSetupModal.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import '../styles/ProfileSetupModal.css';
+
+interface ProfileSetupModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ProfileSetupModal: React.FC<ProfileSetupModalProps> = ({ isOpen, onClose }) => {
+  const navigate = useNavigate();
+
+  if (!isOpen) return null;
+
+  const handleSetupProfile = () => {
+    navigate('/mypage');
+    onClose();
+  };
+
+  return (
+    <div className="profile-setup-modal-overlay">
+      <div className="profile-setup-modal-content">
+        <h2>프로필 설정</h2>
+        <p>프로필을 설정하시면 매칭 기능을 사용하실 수 있습니다.</p>
+        <div className="profile-setup-modal-buttons">
+          <button onClick={handleSetupProfile} className="profile-setup-button primary-button">프로필 설정하기</button>
+          <button onClick={onClose} className="profile-setup-button secondary-button">나중에 하기</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileSetupModal;

--- a/Frontend/editor-recruitment-front/src/hooks/useAuth.ts
+++ b/Frontend/editor-recruitment-front/src/hooks/useAuth.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+interface MemberDetailsRes {
+  maxSubs: number;
+  weeklyWorkload: number;
+  videoTypes: string[];
+  editedChannels: string[];
+  currentChannels: string[];
+  portfolio: string;
+  skills: string[];
+  remarks: string;
+}
+
+interface UserInfo {
+  nickname: string;
+  imageUrl: string;
+  role: string;
+  memberDetailsRes: MemberDetailsRes;
+}
+
+interface ApiResponse {
+  code: string;
+  message: string;
+  data: UserInfo;
+}
+
+export const useAuth = () => {
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const token = sessionStorage.getItem('access-token');
+        if (!token) {
+          setIsLoading(false);
+          return;
+        }
+        const response = await axios.get<ApiResponse>('http://localhost:8080/api/member', {
+          headers: {
+            Authorization: `Bearer ${token}`
+          },
+          withCredentials: true
+        });
+        setUserInfo(response.data.data);
+      } catch (error) {
+        console.error('Failed to fetch user info:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
+  return { userInfo, isLoading };
+};

--- a/Frontend/editor-recruitment-front/src/pages/PostsPage.tsx
+++ b/Frontend/editor-recruitment-front/src/pages/PostsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import NextArrowIcon from '../assets/NextArrowIcon';
@@ -9,6 +9,8 @@ import RecruitmentPostList from '../components/RecruitmentPostList';
 import FilterButtonGroup from '../components/FilterButtonGroup';
 import { FilterOptions } from '../utils/FilterOptions';
 import '../styles/PostsPage.css';
+import { useAuth } from '../hooks/useAuth';
+import ProfileSetupModal from '../components/ProfileSetupModal';
 
 // NextArrow와 PrevArrow 컴포넌트 추가
 const NextArrow = (props: CustomArrowProps) => (
@@ -32,6 +34,8 @@ const PostsPage = () => {
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
   const [selectedVideoTypes, setSelectedVideoTypes] = useState<string[]>([]);
   const [currentPage, setCurrentPage] = useState(0);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { userInfo, isLoading } = useAuth();
 
   const handleOptionToggle = (name: string, type: 'skill' | 'videoType') => {
     if (type === 'skill') {
@@ -46,7 +50,10 @@ const PostsPage = () => {
   };
 
   useEffect(() => {
-  }, [selectedSkills, selectedVideoTypes]);
+    if (!isLoading && userInfo && userInfo.role === 'GUEST') {
+      setIsModalOpen(true);
+    }
+  }, [isLoading, userInfo]);
 
   const settings = {
     dots: false,
@@ -128,6 +135,7 @@ const PostsPage = () => {
           setCurrentPage={setCurrentPage}
         />
       </div>
+      <ProfileSetupModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
     </div>
   );
 };

--- a/Frontend/editor-recruitment-front/src/pages/community/CommunityPostDetailPage.tsx
+++ b/Frontend/editor-recruitment-front/src/pages/community/CommunityPostDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import axios from 'axios';
 import DOMPurify from 'dompurify';
 import '../../styles/CommunityPostDetailPage.css';
@@ -102,7 +102,7 @@ const CommunityPostDetailPage: React.FC = () => {
             <div className="post-header">
                 <div className="author-info">
                     <div className="author-details">
-                        <h2 className="author-name">{post.memberName}</h2>
+                        <Link to={`/member/${post.memberName}`} className="author-name">{post.memberName}</Link>
                         <span className="post-date">{formatDate(post.createdAt)}</span>
                     </div>
                 </div>

--- a/Frontend/editor-recruitment-front/src/pages/member/MemberProfilePage.tsx
+++ b/Frontend/editor-recruitment-front/src/pages/member/MemberProfilePage.tsx
@@ -1,0 +1,189 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import '../../styles/MyProfile.css';
+import { formatNumber } from '../../utils/FormatNumber';
+import premierProIcon from '../../assets/premierProIcon';
+import photoshopIcon from '../../assets/photoshopIcon';
+import afterEffectsIcon from '../../assets/afterEffectsIcon';
+import illustratorIcon from '../../assets/illustratorIcon';
+import chatIcon from '../../assets/chatIcon';
+import radioIcon from '../../assets/radioIcon';
+import gameIcon from '../../assets/gameIcon';
+import foodIcon from '../../assets/foodIcon';
+import educationIcon from '../../assets/educationIcon';
+import reviewIcon from '../../assets/reviewIcon';
+
+interface MemberDetails {
+    maxSubs: number;
+    weeklyWorkload: number;
+    videoTypes: string[];
+    editedChannels: string[];
+    currentChannels: string[];
+    portfolio: string;
+    skills: string[];
+    remarks: string;
+}
+
+interface MemberProfile {
+    nickname: string;
+    imageUrl: string;
+    role: string;
+    memberDetailsRes: MemberDetails;
+}
+
+const filterOptions = [
+    { name: '프리미어 프로', icon: premierProIcon, type: 'skill' },
+    { name: '포토샵', icon: photoshopIcon, type: 'skill' },
+    { name: '에프터 이펙트', icon: afterEffectsIcon, type: 'skill' },
+    { name: '어도비 일러스트', icon: illustratorIcon, type: 'skill' },
+    { name: '저스트 채팅', icon: chatIcon, type: 'videoGenre' },
+    { name: '보이는 라디오', icon: radioIcon, type: 'videoGenre' },
+    { name: '게임', icon: gameIcon, type: 'videoGenre' },
+    { name: '먹방', icon: foodIcon, type: 'videoGenre' },
+    { name: '교육/강의', icon: educationIcon, type: 'videoGenre' },
+    { name: '리뷰/정보', icon: reviewIcon, type: 'videoGenre' },
+];
+
+const MemberProfilePage: React.FC = () => {
+    const { nickname } = useParams<{ nickname: string }>();
+    const [profile, setProfile] = useState<MemberProfile | null>(null);
+    const [loading, setLoading] = useState(true);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const fetchMemberProfile = async () => {
+            setLoading(true);
+            try {
+                const response = await axios.get(`http://localhost:8080/api/member/profile/${nickname}`);
+                setProfile(response.data.data);
+            } catch (error) {
+                console.error('프로필을 불러오는데 실패했습니다.', error);
+                navigate('/not-found');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchMemberProfile();
+    }, [nickname, navigate]);
+
+    if (loading) {
+        return <div className="loading">로딩 중...</div>;
+    }
+
+    if (!profile) {
+        return <div className="error">프로필을 찾을 수 없습니다.</div>;
+    }
+
+    return (
+        <div className="profile-container">
+            <h2 className="page-title">{profile.nickname}의 프로필</h2>
+            
+            <div className="profile-row">
+                <div className="profile-image-container">
+                    <img src={profile.imageUrl} alt={profile.nickname} className="profile-image" />
+                </div>
+                <div className="nickname-container">
+                    <label htmlFor="nickname">닉네임</label>
+                    <input
+                        id="nickname"
+                        type="text"
+                        value={profile.nickname}
+                        readOnly
+                    />
+                </div>
+            </div>
+
+            <div className="profile-section">
+                <h3>역할</h3>
+                <div className="profile-button-group">
+                    <button
+                        className={`profile-role-button ${profile.role === 'CLIENT' ? 'active' : ''}`}
+                        disabled
+                    >
+                        클라이언트
+                    </button>
+                    <button
+                        className={`profile-role-button ${profile.role !== 'CLIENT' ? 'active' : ''}`}
+                        disabled
+                    >
+                        작업자
+                    </button>
+                </div>
+            </div>
+
+            <div className="profile-section">
+                <h3>선호하는 영상 타입</h3>
+                <div className="profile-button-group">
+                    {filterOptions.filter(option => option.type === 'videoGenre').map((option) => (
+                        <button
+                            key={option.name}
+                            className={`profile-filter-button ${profile.memberDetailsRes.videoTypes.includes(option.name) ? 'active' : ''}`}
+                            disabled
+                        >
+                            <option.icon />
+                            {option.name}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            <div className="profile-section">
+                <h3>사용하는 기술</h3>
+                <div className="profile-button-group">
+                    {filterOptions.filter(option => option.type === 'skill').map((option) => (
+                        <button
+                            key={option.name}
+                            className={`profile-filter-button ${profile.memberDetailsRes.skills.includes(option.name) ? 'active' : ''}`}
+                            disabled
+                        >
+                            <option.icon />
+                            {option.name}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            <div className="profile-section">
+                <h3>편집했던 채널</h3>
+                <input
+                    type="text"
+                    value={profile.memberDetailsRes.editedChannels.join(', ')}
+                    readOnly
+                />
+            </div>
+
+            <div className="profile-section">
+                <h3>작업 중인 채널</h3>
+                <input
+                    type="text"
+                    value={profile.memberDetailsRes.currentChannels.join(', ')}
+                    readOnly
+                />
+            </div>
+
+            <div className="profile-section">
+                <h3>최고 구독자 수</h3>
+                <div className="input-with-unit">
+                    <input
+                        type="text"
+                        value={formatNumber(profile.memberDetailsRes.maxSubs.toString())}
+                        readOnly
+                    />
+                    <span className="input-unit">명</span>
+                </div>
+            </div>
+
+            <div className="profile-section">
+                <h3>자기 소개</h3>
+                <textarea
+                    value={profile.memberDetailsRes.remarks}
+                    readOnly
+                />
+            </div>
+        </div>
+    );
+};
+
+export default MemberProfilePage;

--- a/Frontend/editor-recruitment-front/src/pages/recruitment/PostDetailPage.tsx
+++ b/Frontend/editor-recruitment-front/src/pages/recruitment/PostDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import axios from 'axios';
 import DOMPurify from 'dompurify';
 import '../../styles/PostDetailPage.css';
@@ -139,7 +139,7 @@ const PostDetailPage: React.FC = () => {
             <div className="post-header">
                 <div className="author-info">
                     <div className="author-details">
-                        <h2 className="author-name">{post.memberName}</h2>
+                        <Link to={`/member/${post.memberName}`} className="author-name">{post.memberName}</Link>
                         <span className="post-date">{formatDate(post.createdAt)}</span>
                     </div>
                 </div>

--- a/Frontend/editor-recruitment-front/src/styles/MyProfile.css
+++ b/Frontend/editor-recruitment-front/src/styles/MyProfile.css
@@ -226,7 +226,7 @@ textarea {
 .profile-role-button, 
 .profile-filter-button {
     border: 1px solid #B3B3B3 !important;
-    padding: 10px 16px;
+    padding: 8px 16px;
     border-radius: 20px;
     background-color: white;
     cursor: pointer;

--- a/Frontend/editor-recruitment-front/src/styles/ProfileSetupModal.css
+++ b/Frontend/editor-recruitment-front/src/styles/ProfileSetupModal.css
@@ -1,0 +1,77 @@
+.profile-setup-modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1001;
+  }
+  
+  .profile-setup-modal-content {
+    background-color: white;
+    padding: 30px;
+    border-radius: 12px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    max-width: 400px;
+    width: 100%;
+    font-family: 'Pretendard', sans-serif;
+  }
+  
+  .profile-setup-modal-content h2 {
+    margin-top: 0;
+    margin-bottom: 15px;
+    color: #333;
+    font-size: 24px;
+    font-weight: 600;
+  }
+  
+  .profile-setup-modal-content p {
+    color: #666;
+    margin-bottom: 25px;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.5;
+  }
+  
+  .profile-setup-modal-buttons {
+    display: flex;
+    justify-content: space-between;
+    gap: 15px;
+  }
+  
+  .profile-setup-button {
+    padding: 13px 15px;
+    border-radius: 20px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    font-family: 'Pretendard', sans-serif;
+    flex: 1;
+  }
+  
+  .primary-button {
+    background-color: white;
+    border: 1px solid #B3B3B3;
+    color: #333;
+  }
+  
+  .primary-button:hover {
+    background-color: #00CBD6;
+    color: white;
+  }
+  
+  .secondary-button {
+    background-color: white;
+    border: 1px solid #B3B3B3;
+    color: #333;
+  }
+  
+  .secondary-button:hover {
+    background-color: #00CBD6;
+    color: white;
+  }


### PR DESCRIPTION
## 멤버 프로필 페이지 조회 기능 추가 (#49)

- `MemberProfilePage` 컴포넌트 구현
  - `MyProfile` 컴포넌트와 유사한 디자인으로 구현
  - 읽기 전용 기능으로 설정하여 다른 사용자의 프로필 조회 가능
- 백엔드 API 수정
  - 닉네임으로 멤버 프로필 조회 가능하도록 엔드포인트 추가
  - `MemberController`와 `MemberService` 수정
- 프론트엔드와 백엔드 연동
  - 새로운 API 응답 구조에 맞춘 인터페이스 정의
  - axios를 사용한 API 호출 구현


![image](https://github.com/user-attachments/assets/1eff6e83-16fa-42de-860f-886462056d4b)
